### PR TITLE
Add inline trace function which handles start/end calls.

### DIFF
--- a/src/main/java/androidx/os/Trace.kt
+++ b/src/main/java/androidx/os/Trace.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.os.Trace
+import android.support.annotation.RequiresApi
+
+/**
+ * Wrap the specified `block` in calls to [Trace.beginSection] (with the supplied `sectionName`)
+ * and [Trace.endSection].
+ */
+@RequiresApi(18)
+inline fun <T> trace(sectionName: String, block: () -> T): T {
+    Trace.beginSection(sectionName)
+    try {
+        return block()
+    } finally {
+        Trace.endSection()
+    }
+}


### PR DESCRIPTION
As far as I can tell there is no good way of unit or integration testing this. The method body is simple enough, though, that it should not matter.