### PR TITLE
Bump Kotlin version and consolidate repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.2.0'
+      'kotlin': '1.2.10'
   ]
 
   repositories {
-    mavenCentral()
-    google()
     jcenter()
+    google()
   }
 
   dependencies {
@@ -19,7 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
-  mavenCentral()
+  jcenter()
   google()
 }
 


### PR DESCRIPTION
- Change Kotlin plugin version from 1.2.0 to 1.2.10
- Only use jcenter() and google() for repositories

Verified that there are no test regressions.