### PR TITLE
Add Canvas.withSave extension

### DIFF
--- a/src/androidTest/java/androidx/graphics/CanvasTest.kt
+++ b/src/androidTest/java/androidx/graphics/CanvasTest.kt
@@ -32,6 +32,26 @@ class CanvasTest {
     private val values = FloatArray(9)
     private val canvas = Canvas(Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
+    @Suppress("DEPRECATION")
+    @Test fun withSave() {
+        val beforeCount = canvas.saveCount
+
+        canvas.matrix.getValues(values)
+        val x = values[Matrix.MTRANS_X]
+        val y = values[Matrix.MTRANS_Y]
+
+        canvas.withSave {
+            assertThat(beforeCount).isLessThan(saveCount)
+            translate(10.0f, 10.0f)
+        }
+
+        canvas.matrix.getValues(values)
+        assertEquals(x, values[Matrix.MTRANS_X])
+        assertEquals(y, values[Matrix.MTRANS_Y])
+
+        assertEquals(beforeCount, canvas.saveCount)
+    }
+
     @Test fun withTranslation() {
         val beforeCount = canvas.saveCount
         canvas.withTranslation(x = 16.0f, y = 32.0f) {

--- a/src/main/java/androidx/graphics/Canvas.kt
+++ b/src/main/java/androidx/graphics/Canvas.kt
@@ -19,6 +19,19 @@ package androidx.graphics
 import android.graphics.Canvas
 
 /**
+ * Wrap the specified `block` in calls to [Canvas.save]
+ * and [Canvas.restoreToCount].
+ */
+inline fun Canvas.withSave(block: Canvas.() -> Unit) {
+    val checkpoint = save()
+    try {
+        block()
+    } finally {
+        restoreToCount(checkpoint)
+    }
+}
+
+/**
  * Wrap the specified `block` in calls to [Canvas.save]/[Canvas.translate]
  * and [Canvas.restoreToCount].
  */


### PR DESCRIPTION
Automatically wraps a block with a save/restoreToCount pair:

Canvas.withSave {
drawLine(…)
scale(…)
// etc.
}