### PR TITLE
Initial extensions for SparseArray.

### DIFF
--- a/src/androidTest/java/androidx/assertions.kt
+++ b/src/androidTest/java/androidx/assertions.kt
@@ -30,3 +30,5 @@ inline fun <reified T : Throwable> assertThrows(body: () -> Unit): ThrowableSubj
     }
     throw AssertionError("Body completed successfully. Expected ${T::class.java.simpleName}.")
 }
+
+fun fail(message: String? = null): Nothing = throw AssertionError(null)

--- a/src/androidTest/java/androidx/util/SparseArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseArrayTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.util
+
+import android.util.SparseArray
+import androidx.fail
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SparseArrayTest {
+    @Test fun sizeProperty() {
+        val array = SparseArray<String>()
+        assertEquals(0, array.size)
+        array.put(1, "one")
+        assertEquals(1, array.size)
+    }
+
+    @Test fun containsOperator() {
+        val array = SparseArray<String>()
+        assertFalse(1 in array)
+        array.put(1, "one")
+        assertTrue(1 in array)
+    }
+
+    @Test fun setOperator() {
+        val array = SparseArray<String>()
+        array[1] = "one"
+        assertEquals("one", array.get(1))
+    }
+
+    @Test fun plusOperator() {
+        val first = SparseArray<String>().apply { put(1, "one") }
+        val second = SparseArray<String>().apply { put(2, "two") }
+        val combined = first + second
+        assertEquals(2, combined.size())
+        assertEquals(1, combined.keyAt(0))
+        assertEquals("one", combined.valueAt(0))
+        assertEquals(2, combined.keyAt(1))
+        assertEquals("two", combined.valueAt(1))
+    }
+
+    @Test fun containsKey() {
+        val array = SparseArray<String>()
+        assertFalse(array.containsKey(1))
+        array.put(1, "one")
+        assertTrue(array.containsKey(1))
+    }
+
+    @Test fun containsValue() {
+        val array = SparseArray<String>()
+        assertFalse(array.containsValue("one"))
+        array.put(1, "one")
+        assertTrue(array.containsValue("one"))
+    }
+
+    @Test fun getOrDefault() {
+        val array = SparseArray<Any>()
+        val default = Any()
+        assertSame(default, array.getOrDefault(1, default))
+        array.put(1, "one")
+        assertEquals("one", array.getOrDefault(1, default))
+    }
+
+    @Test fun getOrElse() {
+        val array = SparseArray<Any>()
+        val default = Any()
+        assertSame(default, array.getOrElse(1) { default })
+        array.put(1, "one")
+        assertEquals("one", array.getOrElse(1) { fail() })
+    }
+
+    @Test fun isEmpty() {
+        val array = SparseArray<String>()
+        assertTrue(array.isEmpty())
+        array.put(1, "one")
+        assertFalse(array.isEmpty())
+    }
+
+    @Test fun isNotEmpty() {
+        val array = SparseArray<String>()
+        assertFalse(array.isNotEmpty())
+        array.put(1, "one")
+        assertTrue(array.isNotEmpty())
+    }
+
+    @Test fun removeValue() {
+        val array = SparseArray<String>()
+        array.put(1, "one")
+        assertFalse(array.remove(0, "one"))
+        assertEquals(1, array.size())
+        assertFalse(array.remove(1, "two"))
+        assertEquals(1, array.size())
+        assertTrue(array.remove(1, "one"))
+        assertEquals(0, array.size())
+    }
+
+    @Test fun putAll() {
+        val dest = SparseArray<String>()
+        val source = SparseArray<String>()
+        source.put(1, "one")
+
+        assertEquals(0, dest.size())
+        dest.putAll(source)
+        assertEquals(1, dest.size())
+    }
+
+    @Test fun forEach() {
+        val array = SparseArray<String>()
+        array.forEach { _, _ -> fail() }
+
+        array.put(1, "one")
+        array.put(2, "two")
+        array.put(6, "six")
+
+        val keys = mutableListOf<Int>()
+        val values = mutableListOf<String>()
+        array.forEach { key, value ->
+            keys.add(key)
+            values.add(value)
+        }
+        assertThat(keys).containsExactly(1, 2, 6)
+        assertThat(values).containsExactly("one", "two", "six")
+    }
+
+    @Test fun keyIterator() {
+        val array = SparseArray<String>()
+        assertFalse(array.keyIterator().hasNext())
+
+        array.put(1, "one")
+        array.put(2, "two")
+        array.put(6, "six")
+
+        val iterator = array.keyIterator()
+        assertTrue(iterator.hasNext())
+        assertEquals(1, iterator.nextInt())
+        assertTrue(iterator.hasNext())
+        assertEquals(2, iterator.nextInt())
+        assertTrue(iterator.hasNext())
+        assertEquals(6, iterator.nextInt())
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test fun valueIterator() {
+        val array = SparseArray<String>()
+        assertFalse(array.valueIterator().hasNext())
+
+        array.put(1, "one")
+        array.put(2, "two")
+        array.put(6, "six")
+
+        val iterator = array.valueIterator()
+        assertTrue(iterator.hasNext())
+        assertEquals("one", iterator.next())
+        assertTrue(iterator.hasNext())
+        assertEquals("two", iterator.next())
+        assertTrue(iterator.hasNext())
+        assertEquals("six", iterator.next())
+        assertFalse(iterator.hasNext())
+    }
+}

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -21,12 +21,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.assertThrows
+import androidx.fail
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 
 class ViewGroupTest {

--- a/src/main/java/androidx/util/SparseArray.kt
+++ b/src/main/java/androidx/util/SparseArray.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+
+package androidx.util
+
+import android.util.SparseArray
+
+/** Returns the number of key/value pairs in the collection. */
+inline val <T> SparseArray<T>.size get() = size()
+
+/** Returns true if the collection contains [key]. */
+inline operator fun <T> SparseArray<T>.contains(key: Int) = indexOfKey(key) != -1
+
+/** Allows the use of the index operator for storing values in the collection. */
+inline operator fun <T> SparseArray<T>.set(key: Int, value: T) = put(key, value)
+
+/** Creates a new collection by adding or replacing entries from [other]. */
+operator fun <T> SparseArray<T>.plus(other: SparseArray<T>): SparseArray<T> {
+    val new = SparseArray<T>(size() + other.size())
+    new.putAll(this)
+    new.putAll(other)
+    return new
+}
+
+/** Returns true if the collection contains [key]. */
+inline fun <T> SparseArray<T>.containsKey(key: Int) = indexOfKey(key) != -1
+
+/** Returns true if the collection contains [value]. */
+inline fun <T> SparseArray<T>.containsValue(value: T) = indexOfValue(value) != -1
+
+/** Return the value corresponding to [key], or [defaultValue] when not present. */
+inline fun <T> SparseArray<T>.getOrDefault(key: Int, defaultValue: T) = get(key) ?: defaultValue
+
+/** Return the value corresponding to [key], or from [defaultValue] when not present. */
+inline fun <T> SparseArray<T>.getOrElse(key: Int, defaultValue: () -> T) = get(key) ?: defaultValue()
+
+/** Return true when the collection contains no elements. */
+inline fun <T> SparseArray<T>.isEmpty() = size() == 0
+
+/** Return true when the collection contains elements. */
+inline fun <T> SparseArray<T>.isNotEmpty() = size() != 0
+
+/** Removes the entry for [key] only if it is mapped to [value]. */
+fun <T> SparseArray<T>.remove(key: Int, value: T): Boolean {
+    val index = indexOfKey(key)
+    if (index != -1 && value == valueAt(index)) {
+        removeAt(index)
+        return true
+    }
+    return false
+}
+
+/** Update this collection by adding or replacing entries from [other]. */
+fun <T> SparseArray<T>.putAll(other: SparseArray<T>) = other.forEach(::put)
+
+/** Performs the given [action] for each key/value entry. */
+inline fun <T> SparseArray<T>.forEach(action: (Int, T) -> Unit) {
+    for (index in 0 until size()) {
+        action(keyAt(index), valueAt(index))
+    }
+}
+
+/** Return an iterator over the collection's keys. */
+fun <T> SparseArray<T>.keyIterator(): IntIterator = object : IntIterator() {
+    var index = 0
+    override fun hasNext() = index < size()
+    override fun nextInt() = keyAt(index++)
+}
+
+/** Return an iterator over the collection's values. */
+fun <T> SparseArray<T>.valueIterator(): Iterator<T> = object : Iterator<T> {
+    var index = 0
+    override fun hasNext() = index < size()
+    override fun next() = valueAt(index++)
+}


### PR DESCRIPTION
These conform to the collection APIs and extensions in the stdlib for java.util collections.

I have matching ones for LongSparseArray, SparseBooleanArray, SparseIntArray, and SparseLongArray behind it if these are approved.