### PR TITLE
Switch to the Android Dokka plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,13 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.15"
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.15"
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'org.jetbrains.dokka-android'
 
 repositories {
     jcenter()


### PR DESCRIPTION
This prevents R and BuildConfig from showing up in the docs.