### PR TITLE
Add quick task/script for producing a Google maven zip.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ jobs:
           command: ./gradlew assemble assembleAndroidTest --no-daemon
       - store_artifacts:
           path: build/outputs/aar
+      - store_artifacts:
+          path: build/libs
 
       - run:
           name: JVM Tests & Lint
@@ -65,6 +67,12 @@ jobs:
           path: build/reports/lint-results.html
       - store_test_results:
           path: build/reports
+
+      - run:
+          name: Google Maven Zip
+          command: ./gradlew googleZip --no-daemon
+      - store_artifacts:
+          path: build/google.zip
 
       - *save_cache
       - *persist_to_workspace

--- a/build.gradle
+++ b/build.gradle
@@ -144,3 +144,8 @@ artifacts {
     archives dokkaJar
     archives sourcesJar
 }
+
+task googleZip(type: Exec, dependsOn: assemble) {
+    workingDir projectDir
+    commandLine './make-google-zip.sh'
+}

--- a/make-google-zip.sh
+++ b/make-google-zip.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Creates a zip file in the format required for uploading to maven.google.com.
+#
+# Note: If you're on Mac OS you'll need md5sum and sha1sum which can be installed with Homebrew via:
+# brew install md5sha1sum
+#
+# TODO migrate this all to Gradle tasks
+
+set -ex
+
+rm -r build/google-zip || true
+rm build/google.zip || true
+
+mkdir build/google-zip
+cp build/libs/* build/google-zip/
+cp build/outputs/aar/*-release.aar build/google-zip/
+
+for f in build/google-zip/*; do
+  md5sum "$f" > "$f.md5"
+  sha1sum "$f" > "$f.sha1"
+done
+
+zip -0 -r -j build/google.zip build/google-zip


### PR DESCRIPTION
We aren't generating a pom file yet, so the technique used to create this might change in the future, but this is an early take to start testing out how we release.