### PR TITLE
Use support-compat to lower some required APIs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ configurations {
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation "com.android.support:support-annotations:${versions.supportLibrary}"
+    implementation "com.android.support:support-compat:${versions.supportLibrary}"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.android.support:support-annotations:${versions.supportLibrary}"

--- a/src/main/api/0.txt
+++ b/src/main/api/0.txt
@@ -326,7 +326,7 @@ package androidx.os {
 
   public final class TraceKt {
     ctor public TraceKt();
-    method @RequiresApi(18) public static final <T> T! trace(String sectionName, kotlin.jvm.functions.Function0<? extends T> block);
+    method public static final <T> T! trace(String sectionName, kotlin.jvm.functions.Function0<? extends T> block);
   }
 
 }
@@ -638,12 +638,13 @@ package androidx.view {
 
   public final class ViewKt {
     ctor public ViewKt();
-    method @RequiresApi(19) public static final void doOnLayout(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
+    method public static final void doOnLayout(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static final void doOnNextLayout(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static final void doOnPreDraw(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static final Runnable postDelayed(android.view.View, long delayInMillis, kotlin.jvm.functions.Function0<kotlin.Unit> action);
     method @RequiresApi(16) public static final Runnable postOnAnimationDelayed(android.view.View, long delayInMillis, kotlin.jvm.functions.Function0<kotlin.Unit> action);
     method public static final void setPadding(android.view.View, int size);
+    method public static final android.graphics.Bitmap toBitmap(android.view.View, android.graphics.Bitmap.Config config);
     method public static final void updatePadding(android.view.View, int left, int top, int right, int bottom);
     method @RequiresApi(17) public static final void updatePaddingRelative(android.view.View, int start, int top, int end, int bottom);
   }

--- a/src/main/java/androidx/os/Trace.kt
+++ b/src/main/java/androidx/os/Trace.kt
@@ -17,18 +17,17 @@
 package androidx.os
 
 import android.os.Trace
-import android.support.annotation.RequiresApi
+import android.support.v4.os.TraceCompat
 
 /**
  * Wrap the specified `block` in calls to [Trace.beginSection] (with the supplied `sectionName`)
  * and [Trace.endSection].
  */
-@RequiresApi(18)
 inline fun <T> trace(sectionName: String, block: () -> T): T {
-    Trace.beginSection(sectionName)
+    TraceCompat.beginSection(sectionName)
     try {
         return block()
     } finally {
-        Trace.endSection()
+        TraceCompat.endSection()
     }
 }

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -18,6 +18,7 @@ package androidx.view
 
 import android.graphics.Bitmap
 import android.support.annotation.RequiresApi
+import android.support.v4.view.ViewCompat
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.graphics.applyCanvas
@@ -44,9 +45,8 @@ inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) {
  *
  * @see doOnNextLayout
  */
-@RequiresApi(19)
 inline fun View.doOnLayout(crossinline action: (view: View) -> Unit) {
-    if (isLaidOut) {
+    if (ViewCompat.isLaidOut(this)) {
         action(this)
     } else {
         doOnNextLayout {
@@ -159,9 +159,8 @@ fun View.postOnAnimationDelayed(delayInMillis: Long, action: () -> Unit): Runnab
  *
  * @param config Bitmap config of the desired bitmap. Defaults to [Config.ARGB_8888].
  */
-@RequiresApi(19)
 fun View.toBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Bitmap {
-    if (!isLaidOut) {
+    if (!ViewCompat.isLaidOut(this)) {
         throw IllegalStateException("View needs to be laid out before calling toBitmap()")
     }
     return Bitmap.createBitmap(width, height, config).applyCanvas(::draw)


### PR DESCRIPTION
This contains a metalava change required to use the support-compat aar, and it's presented as a different commit if you want to review them separately.