### PR TITLE
Update AGP to 3.1 so that lint runs on Kotlin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.15"
     }
@@ -39,6 +39,10 @@ android {
         minSdkVersion 14
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
+    lintOptions {
+        checkTestSources true
     }
 
     // TODO replace with https://issuetracker.google.com/issues/72050365 once released.

--- a/src/androidTest/java/androidx/testing.kt
+++ b/src/androidTest/java/androidx/testing.kt
@@ -16,6 +16,7 @@
 
 package androidx
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.support.annotation.LayoutRes
 import android.util.AttributeSet
@@ -38,6 +39,7 @@ inline fun <reified T : Throwable> assertThrows(body: () -> Unit): ThrowableSubj
 
 fun fail(message: String? = null): Nothing = throw AssertionError(message)
 
+@SuppressLint("ResourceType")
 fun Context.getAttributeSet(@LayoutRes layoutId: Int): AttributeSet {
     val parser = resources.getXml(layoutId)
     var type = parser.next()

--- a/src/androidTest/java/androidx/util/HalfTest.kt
+++ b/src/androidTest/java/androidx/util/HalfTest.kt
@@ -16,11 +16,13 @@
 
 package androidx.util
 
+import android.annotation.SuppressLint
 import android.util.Half
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class HalfTest {
+    @SuppressLint("HalfFloat") // TODO remove https://issuetracker.google.com/issues/72509078
     @Test fun shortToHalf() = assertEquals(Half(1.toShort()), 1.toShort().toHalf())
 
     @Test fun floatToHalf() = assertEquals(Half(1f), 1f.toHalf())

--- a/src/main/java/androidx/util/Half.kt
+++ b/src/main/java/androidx/util/Half.kt
@@ -18,11 +18,13 @@
 
 package androidx.util
 
+import android.annotation.SuppressLint
 import android.support.annotation.HalfFloat
 import android.support.annotation.RequiresApi
 import android.util.Half
 
 @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET_ON_TYPE") // TODO https://youtrack.jetbrains.com/issue/KT-21696
+@SuppressLint("HalfFloat") // TODO remove https://issuetracker.google.com/issues/72509078
 @RequiresApi(26)
 inline fun @receiver:HalfFloat Short.toHalf(): Half = Half.valueOf(this)
 


### PR DESCRIPTION
Suppress two false positives and an intentional resource type deviation.