### PR TITLE
Only run tests on API levels where they are supported.

### DIFF
--- a/src/androidTest/java/androidx/animation/AnimatorTest.kt
+++ b/src/androidTest/java/androidx/animation/AnimatorTest.kt
@@ -20,6 +20,7 @@ import android.animation.Animator
 import android.animation.ObjectAnimator
 import android.support.test.InstrumentationRegistry
 import android.support.test.annotation.UiThreadTest
+import android.support.test.filters.SdkSuppress
 import android.support.test.runner.AndroidJUnit4
 import android.view.View
 import org.junit.Assert.assertTrue
@@ -79,6 +80,7 @@ class AnimatorTest {
     }
 
     @UiThreadTest
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testDoOnPause() {
         var called = false
         animator.doOnPause {
@@ -94,6 +96,7 @@ class AnimatorTest {
     }
 
     @UiThreadTest
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testDoOnResume() {
         var called = false
         animator.doOnResume {

--- a/src/androidTest/java/androidx/content/ContextTest.kt
+++ b/src/androidTest/java/androidx/content/ContextTest.kt
@@ -17,6 +17,7 @@
 package androidx.content
 
 import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
 import android.test.mock.MockContext
 import androidx.getAttributeSet
 import androidx.kotlin.test.R
@@ -28,6 +29,7 @@ import org.junit.Test
 class ContextTest {
     private val context = InstrumentationRegistry.getContext()
 
+    @SdkSuppress(minSdkVersion = 23)
     @Test fun systemService() {
         var lookup: Class<*>? = null
         val context = object : MockContext() {

--- a/src/androidTest/java/androidx/content/res/TypedArrayTest.kt
+++ b/src/androidTest/java/androidx/content/res/TypedArrayTest.kt
@@ -18,6 +18,7 @@ package androidx.content.res
 
 import android.graphics.Color
 import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
 import androidx.assertThrows
 import androidx.getAttributeSet
 import androidx.kotlin.test.R
@@ -118,6 +119,7 @@ class TypedArrayTest {
         }.hasMessageThat().isEqualTo("Attribute not defined in set.")
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun font() {
         val attrs = context.getAttributeSet(R.layout.typed_array)
         val array = context.obtainStyledAttributes(attrs, R.styleable.TypedArrayTypes)

--- a/src/androidTest/java/androidx/database/sqlite/SQLiteDatabaseTest.kt
+++ b/src/androidTest/java/androidx/database/sqlite/SQLiteDatabaseTest.kt
@@ -45,9 +45,9 @@ class SQLiteDatabaseTest {
             }
         }.isSameAs(exception)
 
-        db.rawQuery("SELECT COUNT(*) FROM test", emptyArray()).use {
-            it.moveToFirst()
-            assertEquals(0L, it.getLong(0))
-        }
+        val query = db.rawQuery("SELECT COUNT(*) FROM test", emptyArray())
+        query.moveToFirst()
+        assertEquals(0L, query.getLong(0))
+        query.close()
     }
 }

--- a/src/androidTest/java/androidx/graphics/BitmapTest.kt
+++ b/src/androidTest/java/androidx/graphics/BitmapTest.kt
@@ -18,24 +18,28 @@ package androidx.graphics
 
 import android.graphics.Bitmap
 import android.graphics.ColorSpace
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BitmapTest {
     @Test fun create() {
-        val b1 = createBitmap(7, 9)
-        assertEquals(7, b1.width)
-        assertEquals(9, b1.height)
-        assertEquals(Bitmap.Config.ARGB_8888, b1.config)
-        assertTrue(b1.colorSpace.isSrgb)
+        val bitmap = createBitmap(7, 9)
+        assertEquals(7, bitmap.width)
+        assertEquals(9, bitmap.height)
+        assertEquals(Bitmap.Config.ARGB_8888, bitmap.config)
+    }
 
-        val b2 = createBitmap(7, 9, config = Bitmap.Config.RGBA_F16)
-        assertEquals(Bitmap.Config.RGBA_F16, b2.config)
+    @Test fun createWithConfig() {
+        val bitmap = createBitmap(7, 9, config = Bitmap.Config.RGB_565)
+        assertEquals(Bitmap.Config.RGB_565, bitmap.config)
+    }
 
+    @SdkSuppress(minSdkVersion = 26)
+    @Test fun createWithColorSpace() {
         val colorSpace = ColorSpace.get(ColorSpace.Named.ADOBE_RGB)
-        val b3 = createBitmap(7, 9, colorSpace = colorSpace)
-        assertEquals(colorSpace, b3.colorSpace)
+        val bitmap = createBitmap(7, 9, colorSpace = colorSpace)
+        assertEquals(colorSpace, bitmap.colorSpace)
     }
 
     @Test fun scale() {

--- a/src/androidTest/java/androidx/graphics/ColorTest.kt
+++ b/src/androidTest/java/androidx/graphics/ColorTest.kt
@@ -18,12 +18,14 @@ package androidx.graphics
 
 import android.graphics.Color
 import android.graphics.ColorSpace
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ColorTest {
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun destructuringColor() {
         val (r, g, b, a) = 0x337f3010.toColor()
         assertEquals(0.5f, r, 1e-2f)
@@ -40,21 +42,29 @@ class ColorTest {
         assertEquals(0x10, b)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun intToColor() = assertEquals(Color.valueOf(0x337f3010), 0x337f3010.toColor())
+
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun intToColorLong() = assertEquals(Color.pack(0x337f3010), 0x337f3010.toColorLong())
 
     @Test fun alpha() = assertEquals(0x33, 0x337f3010.alpha)
     @Test fun red() = assertEquals(0x7f, 0x337f3010.red)
     @Test fun green() = assertEquals(0x30, 0x337f3010.green)
     @Test fun blue() = assertEquals(0x10, 0x337f3010.blue)
+
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun luminance() = assertEquals(0.212f, 0xff7f7f7f.toInt().luminance, 1e-3f)
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun longToColor() {
         assertEquals(Color.valueOf(0x337f3010), Color.pack(0x337f3010).toColor())
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun longToColorInt() = assertEquals(0x337f3010, Color.pack(0x337f3010).toColorInt())
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun destructuringLong() {
         val (r, g, b, a) = Color.pack(0x337f3010)
         assertEquals(0.20f, a, 1e-2f)
@@ -63,27 +73,38 @@ class ColorTest {
         assertEquals(0.06f, b, 1e-2f)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun alphaLong() = assertEquals(0.20f, Color.pack(0x337f3010).alpha, 1e-2f)
+
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun redLong() = assertEquals(0.50f, Color.pack(0x337f3010).red, 1e-2f)
+
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun greenLong() = assertEquals(0.19f, Color.pack(0x337f3010).green, 1e-2f)
+
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun blueLong() = assertEquals(0.06f, Color.pack(0x337f3010).blue, 1e-2f)
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun luminanceLong() {
         assertEquals(0.212f, Color.pack(0xff7f7f7f.toInt()).luminance, 1e-3f)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun isSrgb() {
         assertTrue(0x337f3010.toColorLong().isSrgb)
         val c = Color.pack(1.0f, 0.0f, 0.0f, 1.0f, ColorSpace.get(ColorSpace.Named.BT2020))
         assertFalse(c.isSrgb)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun isWideGamut() {
         assertFalse(0x337f3010.toColorLong().isWideGamut)
         val c = Color.pack(1.0f, 0.0f, 0.0f, 1.0f, ColorSpace.get(ColorSpace.Named.BT2020))
         assertTrue(c.isWideGamut)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun getColorSpace() {
         val sRGB = ColorSpace.get(ColorSpace.Named.SRGB)
         assertEquals(sRGB, 0x337f3010.toColorLong().colorSpace)
@@ -93,6 +114,7 @@ class ColorTest {
         assertEquals(bt2020, c.colorSpace)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test(expected = IllegalArgumentException::class) fun addColorsDifferentModels() {
         val lab = Color.valueOf(
                 floatArrayOf(54.0f, 80.0f, 70.0f, 1.0f),
@@ -102,6 +124,7 @@ class ColorTest {
         lab + rgb
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun addColorsSameColorSpace() {
         val (r, g, b, a) = 0x7f7f0000.toColor() + 0x7f007f00.toColor()
         assertEquals(0.16f, r, 1e-2f)
@@ -110,6 +133,7 @@ class ColorTest {
         assertEquals(0.75f, a, 1e-2f)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun addColorsDifferentColorSpace() {
         val p3 = ColorSpace.get(ColorSpace.Named.DISPLAY_P3)
         val red = Color.valueOf(0.5f, 0.0f, 0.0f, 0.5f, p3)
@@ -125,6 +149,7 @@ class ColorTest {
         assertEquals(0.75f, a, 1e-2f)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun addColorsZeroAlpha() {
         // Test potential divide by zero
         assertEquals(0, (0x007f0000.toColor() + 0x00007f00.toColor()).toArgb())

--- a/src/androidTest/java/androidx/graphics/PathTest.kt
+++ b/src/androidTest/java/androidx/graphics/PathTest.kt
@@ -19,6 +19,7 @@ package androidx.graphics
 import android.graphics.Path
 import android.graphics.PointF
 import android.graphics.RectF
+import android.support.test.filters.SdkSuppress
 import androidx.fail
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -26,10 +27,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PathTest {
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun testFlattenEmptyPath() {
         Path().flatten().forEach { fail("An empty path should not have segments: " + it) }
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun testFlatten() {
         val p = Path()
 
@@ -81,6 +84,7 @@ class PathTest {
         assertEquals(3, count)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testUnion() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 10.0f, 10.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 0.0f, 15.0f, 15.0f, Path.Direction.CW) }
@@ -92,6 +96,7 @@ class PathTest {
         assertEquals(RectF(0.0f, 0.0f, 15.0f, 15.0f), r)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testAnd() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 10.0f, 10.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 0.0f, 15.0f, 15.0f, Path.Direction.CW) }
@@ -103,6 +108,7 @@ class PathTest {
         assertEquals(RectF(0.0f, 0.0f, 15.0f, 15.0f), r)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testDifference() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 10.0f, 10.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 0.0f, 15.0f, 15.0f, Path.Direction.CW) }
@@ -114,6 +120,7 @@ class PathTest {
         assertEquals(RectF(0.0f, 0.0f, 5.0f, 10.0f), r)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testIntersection() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 10.0f, 10.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 0.0f, 15.0f, 15.0f, Path.Direction.CW) }
@@ -125,6 +132,7 @@ class PathTest {
         assertEquals(RectF(5.0f, 0.0f, 10.0f, 10.0f), r)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testEmptyIntersection() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 2.0f, 2.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 5.0f, 7.0f, 7.0f, Path.Direction.CW) }
@@ -133,6 +141,7 @@ class PathTest {
         assertTrue(p.isEmpty)
     }
 
+    @SdkSuppress(minSdkVersion = 19)
     @Test fun testXor() {
         val r1 = Path().apply { addRect(0.0f, 0.0f, 10.0f, 10.0f, Path.Direction.CW) }
         val r2 = Path().apply { addRect(5.0f, 5.0f, 15.0f, 15.0f, Path.Direction.CW) }

--- a/src/androidTest/java/androidx/graphics/PictureTest.kt
+++ b/src/androidTest/java/androidx/graphics/PictureTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 class PictureTest {
     @Test fun record() {
         val p = Picture().record(1, 1) {
-            drawColor(Color.valueOf(1.0f, 0.0f, 0.0f).toArgb())
+            drawColor(Color.RED)
         }
         val v = createBitmap(1, 1).applyCanvas {
             drawPicture(p)

--- a/src/androidTest/java/androidx/graphics/PointTest.kt
+++ b/src/androidTest/java/androidx/graphics/PointTest.kt
@@ -95,7 +95,9 @@ class PointTest {
     }
 
     @Test fun toPointF() {
-        assertEquals(PointF(1.0f, 2.0f), Point(1, 2).toPointF())
+        val pointF = Point(1, 2).toPointF()
+        assertEquals(1f, pointF.x, 0f)
+        assertEquals(2f, pointF.y, 0f)
     }
 
     @Test fun toPoint() {

--- a/src/androidTest/java/androidx/graphics/RectTest.kt
+++ b/src/androidTest/java/androidx/graphics/RectTest.kt
@@ -193,9 +193,11 @@ class RectTest {
     }
 
     @Test fun toRectF() {
-        assertEquals(
-                RectF(0f, 1f, 2f, 3f),
-                Rect(0, 1, 2, 3).toRectF())
+        val rectF = Rect(0, 1, 2, 3).toRectF()
+        assertEquals(0f, rectF.left, 0f)
+        assertEquals(1f, rectF.top, 0f)
+        assertEquals(2f, rectF.right, 0f)
+        assertEquals(3f, rectF.bottom, 0f)
     }
 
     @Test fun toRegionInt() {
@@ -211,7 +213,10 @@ class RectTest {
         m.setScale(2.0f, 2.0f)
 
         val r = RectF(2.0f, 2.0f, 5.0f, 7.0f).transform(m)
-        assertEquals(RectF(4.0f, 4.0f, 10.0f, 14.0f), r)
+        assertEquals(4f, r.left, 0f)
+        assertEquals(4f, r.top, 0f)
+        assertEquals(10f, r.right, 0f)
+        assertEquals(14f, r.bottom, 0f)
     }
 
     @Test fun transformRectNotPreserved() {

--- a/src/androidTest/java/androidx/graphics/drawable/DrawableTest.kt
+++ b/src/androidTest/java/androidx/graphics/drawable/DrawableTest.kt
@@ -113,10 +113,10 @@ class DrawableTest {
             override fun getIntrinsicHeight() = 10
         }
 
-        val bitmap = drawable.toBitmap(config = Config.RGBA_F16)
+        val bitmap = drawable.toBitmap(config = Config.RGB_565)
         assertEquals(10, bitmap.width)
         assertEquals(10, bitmap.height)
-        assertEquals(Config.RGBA_F16, bitmap.config)
+        assertEquals(Config.RGB_565, bitmap.config)
         assertEquals(Color.RED, bitmap.getPixel(5, 5))
     }
 

--- a/src/androidTest/java/androidx/os/BundleTest.kt
+++ b/src/androidTest/java/androidx/os/BundleTest.kt
@@ -20,6 +20,7 @@ import android.graphics.Rect
 import android.os.Binder
 import android.os.Bundle
 import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
 import android.util.Size
 import android.util.SizeF
 import android.view.View
@@ -34,11 +35,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class BundleTest {
     @Test fun bundleOfValid() {
-        val binderValue = Binder()
         val bundleValue = Bundle()
         val charSequenceValue = "hey"
-        val sizeValue = Size(1, 1)
-        val sizeFValue = SizeF(1f, 1f)
         val parcelableValue = Rect(1, 2, 3, 4)
         val serializableValue = AtomicInteger(1)
 
@@ -54,11 +52,8 @@ class BundleTest {
                 "long" to 1L,
                 "short" to 1.toShort(),
 
-                "binder" to binderValue,
                 "bundle" to bundleValue,
                 "charSequence" to charSequenceValue,
-                "size" to sizeValue,
-                "sizeF" to sizeFValue,
                 "parcelable" to parcelableValue,
 
                 "booleanArray" to booleanArrayOf(),
@@ -78,7 +73,7 @@ class BundleTest {
                 "serializable" to serializableValue
         )
 
-        assertEquals(28, bundle.size())
+        assertEquals(25, bundle.size())
 
         assertNull(bundle["null"])
 
@@ -91,11 +86,8 @@ class BundleTest {
         assertEquals(1L, bundle["long"])
         assertEquals(1.toShort(), bundle["short"])
 
-        assertSame(binderValue, bundle["binder"])
         assertSame(bundleValue, bundle["bundle"])
         assertSame(charSequenceValue, bundle["charSequence"])
-        assertSame(sizeValue, bundle["size"])
-        assertSame(sizeFValue, bundle["sizeF"])
         assertSame(parcelableValue, bundle["parcelable"])
 
         assertArrayEquals(booleanArrayOf(), bundle["booleanArray"] as BooleanArray)
@@ -113,6 +105,27 @@ class BundleTest {
         assertThat(bundle["serializableArray"] as Array<*>).asList().containsExactly(serializableValue)
 
         assertSame(serializableValue, bundle["serializable"])
+    }
+
+    @SdkSuppress(minSdkVersion = 18)
+    @Test fun bundleOfValidApi18() {
+        val binderValue = Binder()
+        val bundle = bundleOf("binder" to binderValue)
+        assertSame(binderValue, bundle["binder"])
+    }
+
+    @SdkSuppress(minSdkVersion = 21)
+    @Test fun bundleOfValidApi21() {
+        val sizeValue = Size(1, 1)
+        val sizeFValue = SizeF(1f, 1f)
+
+        val bundle = bundleOf(
+                "size" to sizeValue,
+                "sizeF" to sizeFValue
+        )
+
+        assertSame(sizeValue, bundle["size"])
+        assertSame(sizeFValue, bundle["sizeF"])
     }
 
     @Test fun bundleOfInvalid() {

--- a/src/androidTest/java/androidx/os/HandlerTest.kt
+++ b/src/androidTest/java/androidx/os/HandlerTest.kt
@@ -19,6 +19,7 @@ package androidx.os
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.SystemClock
+import android.support.test.filters.SdkSuppress
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -40,7 +41,7 @@ class HandlerTest {
     }
 
     @After fun after() {
-        handlerThread.quitSafely()
+        handlerThread.quit()
     }
 
     @Test fun postDelayedWithToken() {
@@ -105,6 +106,7 @@ class HandlerTest {
         assertEquals(0, called)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun postDelayedLambdaDuration() {
         var called = 0
         handler.postDelayed(Duration.ofMillis(10)) {
@@ -115,6 +117,7 @@ class HandlerTest {
         assertEquals(1, called)
     }
 
+    @SdkSuppress(minSdkVersion = 26)
     @Test fun postDelayedLambdaDurationRemoved() {
         var called = 0
         val runnable = handler.postDelayed(Duration.ofMillis(10)) {

--- a/src/androidTest/java/androidx/os/PersistableBundleTest.kt
+++ b/src/androidTest/java/androidx/os/PersistableBundleTest.kt
@@ -32,14 +32,12 @@ class PersistableBundleTest {
         val bundle = persistableBundleOf(
                 "null" to null,
 
-                "boolean" to true,
                 "double" to 1.0,
                 "int" to 1,
                 "long" to 1L,
 
                 "string" to "hey",
 
-                "booleanArray" to booleanArrayOf(),
                 "doubleArray" to doubleArrayOf(),
                 "intArray" to intArrayOf(),
                 "longArray" to longArrayOf(),
@@ -47,23 +45,32 @@ class PersistableBundleTest {
                 "stringArray" to arrayOf("hey")
         )
 
-        assertEquals(11, bundle.size())
+        assertEquals(9, bundle.size())
 
         assertNull(bundle["null"])
 
-        assertEquals(true, bundle["boolean"])
         assertEquals(1.0, bundle["double"])
         assertEquals(1, bundle["int"])
         assertEquals(1L, bundle["long"])
 
         assertEquals("hey", bundle["string"])
 
-        assertArrayEquals(booleanArrayOf(), bundle["booleanArray"] as BooleanArray)
         assertArrayEquals(doubleArrayOf(), bundle["doubleArray"] as DoubleArray, 0.0)
         assertArrayEquals(intArrayOf(), bundle["intArray"] as IntArray)
         assertArrayEquals(longArrayOf(), bundle["longArray"] as LongArray)
 
         assertThat(bundle["stringArray"] as Array<*>).asList().containsExactly("hey")
+    }
+
+    @SdkSuppress(minSdkVersion = 22)
+    @Test fun persistableBundleOfValidApi22() {
+        val bundle = persistableBundleOf(
+                "boolean" to true,
+                "booleanArray" to booleanArrayOf()
+        )
+
+        assertEquals(true, bundle["boolean"])
+        assertArrayEquals(booleanArrayOf(), bundle["booleanArray"] as BooleanArray)
     }
 
     @Test fun persistableBundleOfInvalid() {

--- a/src/androidTest/java/androidx/time/DayOfWeekTest.kt
+++ b/src/androidTest/java/androidx/time/DayOfWeekTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.DayOfWeek
 
+@SdkSuppress(minSdkVersion = 26)
 class DayOfWeekTest {
     @Test fun fromInt() {
         assertEquals(DayOfWeek.MONDAY, 1.asDayOfWeek())

--- a/src/androidTest/java/androidx/time/DurationTest.kt
+++ b/src/androidTest/java/androidx/time/DurationTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Duration
 
+@SdkSuppress(minSdkVersion = 26)
 class DurationTest {
     @Test fun destructuring() {
         val (seconds, nanos) = Duration.ofSeconds(12, 3456789)

--- a/src/androidTest/java/androidx/time/InstantTest.kt
+++ b/src/androidTest/java/androidx/time/InstantTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Instant
 
+@SdkSuppress(minSdkVersion = 26)
 class InstantTest {
     @Test fun destructuring() {
         val (seconds, nanos) = Instant.ofEpochSecond(12, 3456789)

--- a/src/androidTest/java/androidx/time/LocalDateTest.kt
+++ b/src/androidTest/java/androidx/time/LocalDateTest.kt
@@ -16,11 +16,13 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate
 import java.time.Month
 
+@SdkSuppress(minSdkVersion = 26)
 class LocalDateTest {
     @Test fun destructuring() {
         val (year, month, day) = LocalDate.of(2017, 12, 20)

--- a/src/androidTest/java/androidx/time/LocalDateTimeTest.kt
+++ b/src/androidTest/java/androidx/time/LocalDateTimeTest.kt
@@ -16,12 +16,14 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
+@SdkSuppress(minSdkVersion = 26)
 class LocalDateTimeTest {
     @Test fun destructuring() {
         val actualDate = LocalDate.of(2017, 12, 20)

--- a/src/androidTest/java/androidx/time/LocalTimeTest.kt
+++ b/src/androidTest/java/androidx/time/LocalTimeTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalTime
 
+@SdkSuppress(minSdkVersion = 26)
 class LocalTimeTest {
     @Test fun destructuring() {
         val (hour, minute, second, nanos) = LocalTime.of(5, 12, 42, 55678)

--- a/src/androidTest/java/androidx/time/MonthDayTest.kt
+++ b/src/androidTest/java/androidx/time/MonthDayTest.kt
@@ -16,11 +16,13 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Month
 import java.time.MonthDay
 
+@SdkSuppress(minSdkVersion = 26)
 class MonthDayTest {
     @Test fun destructuring() {
         val (month, day) = MonthDay.of(Month.DECEMBER, 20)

--- a/src/androidTest/java/androidx/time/MonthTest.kt
+++ b/src/androidTest/java/androidx/time/MonthTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Month
 
+@SdkSuppress(minSdkVersion = 26)
 class MonthTest {
     @Test fun fromInt() {
         assertEquals(Month.DECEMBER, 12.asMonth())

--- a/src/androidTest/java/androidx/time/OffsetDateTimeTest.kt
+++ b/src/androidTest/java/androidx/time/OffsetDateTimeTest.kt
@@ -16,12 +16,14 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
+@SdkSuppress(minSdkVersion = 26)
 class OffsetDateTimeTest {
     @Test fun destructuring() {
         val (dateTime, offset) = OffsetDateTime.of(2017, 12, 20, 5, 16, 42, 0, ZoneOffset.UTC)

--- a/src/androidTest/java/androidx/time/OffsetTimeTest.kt
+++ b/src/androidTest/java/androidx/time/OffsetTimeTest.kt
@@ -16,12 +16,14 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
 
+@SdkSuppress(minSdkVersion = 26)
 class OffsetTimeTest {
     @Test fun destructuring() {
         val (time, offset) = OffsetTime.of(5, 16, 42, 0, ZoneOffset.UTC)

--- a/src/androidTest/java/androidx/time/PeriodTest.kt
+++ b/src/androidTest/java/androidx/time/PeriodTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Period
 
+@SdkSuppress(minSdkVersion = 26)
 class PeriodTest {
     @Test fun destructuring() {
         val (years, months, days) = Period.of(10, 3, 22)

--- a/src/androidTest/java/androidx/time/YearMonthTest.kt
+++ b/src/androidTest/java/androidx/time/YearMonthTest.kt
@@ -16,11 +16,13 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Month
 import java.time.YearMonth
 
+@SdkSuppress(minSdkVersion = 26)
 class YearMonthTest {
     @Test fun destructuring() {
         val (year, month) = YearMonth.of(2017, 12)

--- a/src/androidTest/java/androidx/time/YearTest.kt
+++ b/src/androidTest/java/androidx/time/YearTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Year
 
+@SdkSuppress(minSdkVersion = 26)
 class YearTest {
     @Test fun fromInt() {
         assertEquals(Year.of(2017), 2017.asYear())

--- a/src/androidTest/java/androidx/time/ZonedDateTimeTest.kt
+++ b/src/androidTest/java/androidx/time/ZonedDateTimeTest.kt
@@ -16,12 +16,14 @@
 
 package androidx.time
 
+import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
+@SdkSuppress(minSdkVersion = 26)
 class ZonedDateTimeTest {
     @Test fun destructuring() {
         val paris = ZoneId.of("Europe/Paris")

--- a/src/androidTest/java/androidx/util/ArrayMapTest.kt
+++ b/src/androidTest/java/androidx/util/ArrayMapTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 19)
 class ArrayMapTest {
     @Test fun empty() {
         val map = arrayMapOf<String, String>()

--- a/src/androidTest/java/androidx/util/ArraySetTest.kt
+++ b/src/androidTest/java/androidx/util/ArraySetTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 23)
 class ArraySetTest {
     @Test fun empty() {
         val set = arraySetOf<String>()

--- a/src/androidTest/java/androidx/util/AtomicFileTest.kt
+++ b/src/androidTest/java/androidx/util/AtomicFileTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import android.util.AtomicFile
 import androidx.assertThrows
 import org.junit.Assert.assertArrayEquals
@@ -26,6 +27,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.IOException
 
+@SdkSuppress(minSdkVersion = 17)
 class AtomicFileTest {
     @get:Rule val temporaryFolder = TemporaryFolder()
 

--- a/src/androidTest/java/androidx/util/HalfTest.kt
+++ b/src/androidTest/java/androidx/util/HalfTest.kt
@@ -17,10 +17,12 @@
 package androidx.util
 
 import android.annotation.SuppressLint
+import android.support.test.filters.SdkSuppress
 import android.util.Half
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 26)
 class HalfTest {
     @SuppressLint("HalfFloat") // TODO remove https://issuetracker.google.com/issues/72509078
     @Test fun shortToHalf() = assertEquals(Half(1.toShort()), 1.toShort().toHalf())

--- a/src/androidTest/java/androidx/util/LongSparseArrayTest.kt
+++ b/src/androidTest/java/androidx/util/LongSparseArrayTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import android.util.LongSparseArray
 import androidx.fail
 import com.google.common.truth.Truth.assertThat
@@ -25,6 +26,7 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 16)
 class LongSparseArrayTest {
     @Test fun sizeProperty() {
         val array = LongSparseArray<String>()

--- a/src/androidTest/java/androidx/util/RangeTest.kt
+++ b/src/androidTest/java/androidx/util/RangeTest.kt
@@ -16,10 +16,12 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import android.util.Range
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 21)
 class RangeTest {
     @Test fun infixFactory() {
         val range: Range<String> = "a" rangeTo "c"

--- a/src/androidTest/java/androidx/util/SizeTest.kt
+++ b/src/androidTest/java/androidx/util/SizeTest.kt
@@ -16,11 +16,13 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import android.util.Size
 import android.util.SizeF
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 21)
 class SizeTest {
     @Test fun destructuringSize() {
         val (w, h) = Size(320, 240)

--- a/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.util
 
+import android.support.test.filters.SdkSuppress
 import android.util.SparseLongArray
 import androidx.fail
 import com.google.common.truth.Truth.assertThat
@@ -24,6 +25,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@SdkSuppress(minSdkVersion = 18)
 class SparseLongArrayTest {
     @Test fun sizeProperty() {
         val array = SparseLongArray()

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -17,6 +17,7 @@
 package androidx.view
 
 import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -226,6 +227,7 @@ class ViewGroupTest {
         assertEquals(40, layoutParams.bottomMargin)
     }
 
+    @SdkSuppress(minSdkVersion = 17)
     @Test fun updateMarginsRelative() {
         val layoutParams = ViewGroup.MarginLayoutParams(100, 200)
         layoutParams.updateMarginsRelative(start = 10, end = 20)
@@ -238,6 +240,7 @@ class ViewGroupTest {
         assertTrue(layoutParams.isMarginRelative)
     }
 
+    @SdkSuppress(minSdkVersion = 17)
     @Test fun updateMarginsRelativeNoOp() {
         val layoutParams = ViewGroup.MarginLayoutParams(100, 200)
         layoutParams.setMargins(10, 20, 30, 40)

--- a/src/main/java/androidx/os/Bundle.kt
+++ b/src/main/java/androidx/os/Bundle.kt
@@ -17,8 +17,9 @@
 package androidx.os
 
 import android.annotation.SuppressLint
+import android.os.Binder
+import android.os.Build
 import android.os.Bundle
-import android.os.IBinder
 import android.os.Parcelable
 import android.util.Size
 import android.util.SizeF
@@ -46,11 +47,8 @@ fun bundleOf(vararg pairs: Pair<String, Any?>) = Bundle(pairs.size).apply {
             is Short -> putShort(key, value)
 
             // References
-            is IBinder -> putBinder(key, value)
             is Bundle -> putBundle(key, value)
             is CharSequence -> putCharSequence(key, value)
-            is Size -> putSize(key, value)
-            is SizeF -> putSizeF(key, value)
             is Parcelable -> putParcelable(key, value)
 
             // Scalar arrays
@@ -92,8 +90,16 @@ fun bundleOf(vararg pairs: Pair<String, Any?>) = Bundle(pairs.size).apply {
             is Serializable -> putSerializable(key, value)
 
             else -> {
-                val valueType = value.javaClass.canonicalName
-                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+                if (Build.VERSION.SDK_INT >= 18 && value is Binder) {
+                    putBinder(key, value)
+                } else if (Build.VERSION.SDK_INT >= 21 && value is Size) {
+                    putSize(key, value)
+                } else if (Build.VERSION.SDK_INT >= 21 && value is SizeF) {
+                    putSizeF(key, value)
+                } else {
+                    val valueType = value.javaClass.canonicalName
+                    throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+                }
             }
         }
     }

--- a/src/main/java/androidx/os/PersistableBundle.kt
+++ b/src/main/java/androidx/os/PersistableBundle.kt
@@ -17,6 +17,7 @@
 package androidx.os
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.PersistableBundle
 import android.support.annotation.RequiresApi
 
@@ -33,7 +34,13 @@ fun persistableBundleOf(vararg pairs: Pair<String, Any?>) = PersistableBundle(pa
             null -> putString(key, null) // Any nullable type will suffice.
 
             // Scalars
-            is Boolean -> putBoolean(key, value)
+            is Boolean -> {
+                if (Build.VERSION.SDK_INT >= 22) {
+                    putBoolean(key, value)
+                } else {
+                    throw IllegalArgumentException("Illegal value type boolean for key \"$key\"")
+                }
+            }
             is Double -> putDouble(key, value)
             is Int -> putInt(key, value)
             is Long -> putLong(key, value)
@@ -42,7 +49,13 @@ fun persistableBundleOf(vararg pairs: Pair<String, Any?>) = PersistableBundle(pa
             is String -> putString(key, value)
 
             // Scalar arrays
-            is BooleanArray -> putBooleanArray(key, value)
+            is BooleanArray -> {
+                if (Build.VERSION.SDK_INT >= 22) {
+                    putBooleanArray(key, value)
+                } else {
+                    throw IllegalArgumentException("Illegal value type boolean[] for key \"$key\"")
+                }
+            }
             is DoubleArray -> putDoubleArray(key, value)
             is IntArray -> putIntArray(key, value)
             is LongArray -> putLongArray(key, value)


### PR DESCRIPTION
This also contains some fixes for problems found on older APIs:
* equals is missing for PointF, RectF, etc.
* TransitionManager.endTransition isn't available on 19
* Bundle and PersistableBundle added support for types on various API levels.

For whatever reason the ShaderTest crashes on API 23 and 24. Everything else is good though:
```
Starting 235 tests on Nexus_4_API_15(AVD) - 4.0.4
Starting 260 tests on Nexus_4_API_17(AVD) - 4.2.2
Starting 289 tests on Nexus_4_API_19(AVD) - 4.4.2
Starting 300 tests on Nexus_4_API_21(AVD) - 5.0.2
Starting 304 tests on Nexus_4_API_23(AVD) - 6.0
Starting 304 tests on Nexus_4_API_24(AVD) - 7.0
Starting 370 tests on Nexus_4_API_26(AVD) - 8.0.0

androidx.graphics.ShaderTest > testTransform[Nexus_4_API_23(AVD) - 6.0] FAILED
Test failed to run to completion. Reason: 'Instrumentation run failed due to 'Native crash''. Check device logcat for details
Tests on Nexus_4_API_23(AVD) - 6.0 failed: Instrumentation run failed due to 'Native crash'

androidx.graphics.ShaderTest > testTransform[Nexus_4_API_24(AVD) - 7.0] FAILED
Test failed to run to completion. Reason: 'Instrumentation run failed due to 'Process crashed.''. Check device logcat for details
Tests on Nexus_4_API_24(AVD) - 7.0 failed: Instrumentation run failed due to 'Process crashed.'
```

Closes #114.