### PR TITLE
Delete any existing staging repo before deploying.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,11 @@ uploadArchives {
     }
 }
 
+task deleteGoogleRepo(type: Delete) {
+    delete googleRepo
+}
+uploadArchives.dependsOn(deleteGoogleRepo)
+
 task googleZip(type: Zip, dependsOn: uploadArchives) {
     from googleRepo
 }


### PR DESCRIPTION
This ensures that there is only ever one copy of the artifacts that go into the zip.