### PR TITLE
Add another common extensions

### DIFF
--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -19,9 +19,13 @@ package androidx.content
 import android.content.Context
 import android.content.res.TypedArray
 import android.support.annotation.AttrRes
+import android.support.annotation.LayoutRes
 import android.support.annotation.RequiresApi
 import android.support.annotation.StyleRes
 import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 
 /**
  * Return the handle to a system-level service by class.
@@ -91,3 +95,9 @@ inline fun Context.withStyledAttributes(
         typedArray.recycle()
     }
 }
+
+fun Context.inflate(
+    @LayoutRes layoutId: Int,
+    root: ViewGroup? = null,
+    attachToRoot: Boolean = false
+): View = LayoutInflater.from(this).inflate(layoutId, root, attachToRoot)

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -184,3 +184,8 @@ fun View.toBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Bitmap {
     return Bitmap.createBitmap(width, height, config).applyCanvas(::draw)
 }
 
+var View.isVisible: Boolean
+    get() = visibility == View.VISIBLE
+    set(value) {
+        visibility = if (value) View.VISIBLE else View.GONE
+    }

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -114,6 +114,12 @@ fun View.setPadding(size: Int) {
     setPadding(size, size, size, size)
 }
 
+fun <T : View> T.postApply(action: T.() -> Unit): Runnable {
+    val runnable = Runnable { action(this) }
+    post(runnable)
+    return runnable
+}
+
 /**
  * Version of [View.postDelayed] which re-orders the parameters, allowing the action to be placed
  * outside of parentheses.
@@ -130,6 +136,12 @@ fun View.postDelayed(delayInMillis: Long, action: () -> Unit): Runnable {
     return Runnable(action).apply {
         postDelayed(this, delayInMillis)
     }
+}
+
+fun <T : View> T.postDelayedApply(delayInMillis: Long, action: T.() -> Unit): Runnable {
+    val runnable = Runnable { action(this) }
+    postDelayed(runnable, delayInMillis)
+    return runnable
 }
 
 /**
@@ -171,3 +183,4 @@ fun View.toBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Bitmap {
     }
     return Bitmap.createBitmap(width, height, config).applyCanvas(::draw)
 }
+

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -18,9 +18,11 @@
 
 package androidx.view
 
+import android.support.annotation.LayoutRes
 import android.support.annotation.RequiresApi
 import android.view.View
 import android.view.ViewGroup
+import androidx.content.inflate
 
 /**
  * Returns the view at `index`.
@@ -113,3 +115,8 @@ fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
     marginEnd = end
     bottomMargin = bottom
 }
+
+fun ViewGroup.inflate(
+    @LayoutRes layoutId: Int,
+    attachToRoot: Boolean = false
+): View = context.inflate(layoutId, this, attachToRoot)

--- a/src/main/java/androidx/widget/SeekBar.kt
+++ b/src/main/java/androidx/widget/SeekBar.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.widget
+
+import android.widget.SeekBar
+
+fun SeekBar.doOnProgressChanged(
+    onProgressChanged: (progress: Int, fromUser: Boolean) -> Unit
+) {
+    setOnSeekBarChangeListener(onProgressChanged = onProgressChanged)
+}
+
+fun SeekBar.doOnStartTracking(
+    onStartTracking: () -> Unit
+) {
+    setOnSeekBarChangeListener(onStartTracking = onStartTracking)
+}
+
+fun SeekBar.doOnStopTracking(
+    onStopTracking: () -> Unit
+) {
+    setOnSeekBarChangeListener(onStopTracking = onStopTracking)
+}
+
+fun SeekBar.setOnSeekBarChangeListener(
+    onProgressChanged: ((progress: Int, fromUser: Boolean) -> Unit)? = null,
+    onStartTracking: (() -> Unit)? = null,
+    onStopTracking: (() -> Unit)? = null
+) {
+    setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+            onProgressChanged?.invoke(progress, fromUser)
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar) {
+            onStartTracking?.invoke()
+        }
+
+        override fun onStopTrackingTouch(seekBar: SeekBar) {
+            onStopTracking?.invoke()
+        }
+    })
+}

--- a/src/main/java/androidx/widget/TextView.kt
+++ b/src/main/java/androidx/widget/TextView.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.widget
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.TextView
+
+fun TextView.doAfterChanged(
+    afterChanged: (Editable) -> Unit
+): TextWatcher = addTextChangedListener(afterChanged = afterChanged)
+
+fun TextView.doBeforeChanged(
+    beforeChanged: (s: CharSequence, start: Int, count: Int, after: Int) -> Unit
+): TextWatcher = addTextChangedListener(beforeChanged = beforeChanged)
+
+fun TextView.doOnChanged(
+    onChanged: (s: CharSequence, start: Int, before: Int, count: Int) -> Unit
+): TextWatcher = addTextChangedListener(onChanged = onChanged)
+
+fun TextView.addTextChangedListener(
+    beforeChanged: ((s: CharSequence, start: Int, count: Int, after: Int) -> Unit)? = null,
+    afterChanged: ((Editable) -> Unit)? = null,
+    onChanged: ((s: CharSequence, start: Int, before: Int, count: Int) -> Unit)? = null
+): TextWatcher {
+    val watcher = object : TextWatcher {
+        override fun afterTextChanged(s: Editable) {
+            afterChanged?.invoke(s)
+        }
+
+        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+            beforeChanged?.invoke(s, start, count, after)
+        }
+
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+            onChanged?.invoke(s, start, before, count)
+        }
+    }
+    addTextChangedListener(watcher)
+    return watcher
+}


### PR DESCRIPTION
The purpose of this PR to discuss and add extensions which my colleagues and I use on a daily basis during development. 

I've added extensions for `TextView` and `SeekBar` which allows to attach/set listeners in hande way:

```kotlin
val editText: EditText = ...
editText.doAfterChanged { s: Editable -> }
editText.doBeforeChanged { s, start, count, after ->  }
editText.doOnChanged { s, start, before, count ->  }
    
val seekBar: SeekBar = ...
seekBar.doOnProgressChanged { progress, fromUser ->  }
seekBar.doOnStartTracking {  }
seekBar.doOnStopTracking {  }
```

Another things which I would like to add are version of `post`/`postDelayed` which accept `View` as receiver in block. It is helpful when you want to apply some changes from another thread:
```kotlin
val refreshLayout: SwipeRefreshLayout = ...
refreshLayout.postApply {
    isRefreshing = false
    background = ...
}
```

One more extension is about inflating views directly from `Context` or `ViewGroup`. It is super handy when you working with `RecyclerView`:

```kotlin
override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
        MyViewHolder(parent.inflate(R.layout.my_layout))
```
And the last simple extension is controlling `View` visibility by boolean parameter rather than `View.GONE/View.VISIBLE`:

```kotlin
val view: View = ...
view.isVisible = true
```

Concerns:
- SeekBar listener extensions override each other and can't be used simultaneously
- `postApply/postDelayedApply` returns `Runnable` which inconsistent with Kotlin's `apply` where it returns receiver

In case if you also find this extensions useful I can proceed working with documentations or tests if it is needed from my side.
