### PR TITLE
Fixes Duration.kt methods requiring API level 260

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -369,12 +369,12 @@ package androidx.time {
     method @RequiresApi(26) public static final operator long component1(java.time.Duration);
     method @RequiresApi(26) public static final operator int component2(java.time.Duration);
     method @RequiresApi(26) public static final operator java.time.Duration div(java.time.Duration, long divisor);
-    method @RequiresApi(260) public static final java.time.Duration hours(int);
-    method @RequiresApi(260) public static final java.time.Duration hours(long);
+    method @RequiresApi(26) public static final java.time.Duration hours(int);
+    method @RequiresApi(26) public static final java.time.Duration hours(long);
     method @RequiresApi(26) public static final java.time.Duration millis(int);
     method @RequiresApi(26) public static final java.time.Duration millis(long);
-    method @RequiresApi(260) public static final java.time.Duration minutes(int);
-    method @RequiresApi(260) public static final java.time.Duration minutes(long);
+    method @RequiresApi(26) public static final java.time.Duration minutes(int);
+    method @RequiresApi(26) public static final java.time.Duration minutes(long);
     method @RequiresApi(26) public static final java.time.Duration nanos(int);
     method @RequiresApi(26) public static final java.time.Duration nanos(long);
     method @RequiresApi(26) public static final java.time.Duration seconds(int);

--- a/src/main/java/androidx/time/Duration.kt
+++ b/src/main/java/androidx/time/Duration.kt
@@ -126,7 +126,7 @@ inline fun Long.seconds(): Duration = Duration.ofSeconds(this)
  *
  * @see Duration.ofMinutes
  */
-@RequiresApi(260)
+@RequiresApi(26)
 inline fun Int.minutes(): Duration = Duration.ofMinutes(toLong())
 
 /**
@@ -134,7 +134,7 @@ inline fun Int.minutes(): Duration = Duration.ofMinutes(toLong())
  *
  * @see Duration.ofMinutes
  */
-@RequiresApi(260)
+@RequiresApi(26)
 inline fun Long.minutes(): Duration = Duration.ofMinutes(this)
 
 /**
@@ -142,7 +142,7 @@ inline fun Long.minutes(): Duration = Duration.ofMinutes(this)
  *
  * @see Duration.ofHours
  */
-@RequiresApi(260)
+@RequiresApi(26)
 inline fun Int.hours(): Duration = Duration.ofHours(toLong())
 
 /**
@@ -150,5 +150,5 @@ inline fun Int.hours(): Duration = Duration.ofHours(toLong())
  *
  * @see Duration.ofHours
  */
-@RequiresApi(260)
+@RequiresApi(26)
 inline fun Long.hours(): Duration = Duration.ofHours(this)


### PR DESCRIPTION
This PR removes the invalid API level requirement of 260 and uses the appropriate one required by the android framework one used in the extension.

Instrumented tests were run locally on a Nexus 6P with 8.1.0.

