### PR TITLE
Update README - project only covers framework APIs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ During the preview period, the Android KTX APIs may change at anytime. When the 
 stable state, we will update it to version 1.0 (or later). From that point forward, we will be much
 more rigorous and careful about maintaining API compatibility.
 
+This project does not currently cover the Android Support Library or Architecture Components APIs.
+
 
 Links
 -----


### PR DESCRIPTION
Indicate that this project does not cover the Android Support Library
and Architecture Components APIs.