### PR TITLE
Add FragmentManager extension for transactions

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -14,6 +14,15 @@ package androidx.animation {
 
 }
 
+package androidx.app {
+
+  public final class FragmentManagerKt {
+    ctor public FragmentManagerKt();
+    method public static final void transact(android.app.FragmentManager, kotlin.jvm.functions.Function1<? super android.app.FragmentTransaction,kotlin.Unit> actions);
+  }
+
+}
+
 package androidx.content {
 
   public final class ContentValuesKt {

--- a/src/androidTest/java/androidx/app/FragmentManagerTest.kt
+++ b/src/androidTest/java/androidx/app/FragmentManagerTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.app
+
+import android.app.Fragment
+import android.app.FragmentManager
+import android.app.FragmentTransaction
+import android.support.test.InstrumentationRegistry
+import android.support.test.rule.ActivityTestRule
+import androidx.kotlin.TestActivity
+import androidx.kotlin.test.R
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class FragmentManagerTest {
+    @JvmField @Rule val rule = ActivityTestRule<TestActivity>(TestActivity::class.java)
+
+    private lateinit var fragmentManager: FragmentManager
+    private val fragmentA = Fragment()
+
+    @Before fun setup() {
+        fragmentManager = rule.activity.fragmentManager
+
+        transactOnUiThread {
+            add(R.id.root, fragmentA, "fragmentA")
+        }
+    }
+
+    @Test fun transactAdd() {
+        assertEquals(fragmentManager.findFragmentByTag("fragmentA"), fragmentA)
+    }
+
+    @Test fun transactRemove() {
+        transactOnUiThread {
+            remove(fragmentA)
+        }
+
+        assertNull(fragmentManager.findFragmentByTag("fragmentA"))
+    }
+
+    @Test fun transactReplace() {
+        val fragmentB = Fragment()
+
+        transactOnUiThread {
+            replace(R.id.root, fragmentB, "fragmentB")
+        }
+
+        assertNull(fragmentManager.findFragmentByTag("fragmentA"))
+        assertEquals(fragmentManager.findFragmentByTag("fragmentB"), fragmentB)
+    }
+
+    private fun transactOnUiThread(transaction: FragmentTransaction.() -> Unit) {
+        rule.runOnUiThread {
+            fragmentManager.transact {
+                transaction()
+            }
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+}

--- a/src/main/java/androidx/app/FragmentManager.kt
+++ b/src/main/java/androidx/app/FragmentManager.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.app
+
+import android.app.FragmentManager
+import android.app.FragmentTransaction
+
+/**
+ * Allows performing several Fragment operations within a FragmentTransaction
+ * with a call to [FragmentTransaction.commit] to schedule a commit
+ * for the provided Fragment operations.
+ *
+ * ```
+ * fragmentManager.transact {
+ *     remove(fragmentOne)
+ *     add(R.id.fragment_container, fragmentTwo)
+ * }
+ * ```
+ */
+inline fun FragmentManager.transact(actions: FragmentTransaction.() -> Unit) {
+    val transaction = beginTransaction()
+    actions(transaction)
+    transaction.commit()
+}


### PR DESCRIPTION
Add extension to execute `FragmentTransaction` in a handy way
 ```
 fragmentManager.transact {
    remove(fragmentOne)
    add(R.id.fragment_container, fragmentTwo)
 }
```