### PR TITLE
Add children val to ViewGroup which returns a Sequence<View>

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -645,6 +645,7 @@ package androidx.view {
     method public static final void forEach(android.view.ViewGroup, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static final void forEachIndexed(android.view.ViewGroup, kotlin.jvm.functions.Function2<? super Integer,? super android.view.View,kotlin.Unit> action);
     method public static final operator android.view.View get(android.view.ViewGroup, int index);
+    method public static final kotlin.sequences.Sequence<android.view.View> getChildren(android.view.ViewGroup);
     method public static final int getSize(android.view.ViewGroup);
     method public static final boolean isEmpty(android.view.ViewGroup);
     method public static final boolean isNotEmpty(android.view.ViewGroup);

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -203,11 +203,8 @@ class ViewGroupTest {
         val views = listOf(View(context), View(context), View(context))
         views.forEach { viewGroup.addView(it) }
 
-        var index = 0
-        viewGroup
-                .children
-                .forEach { child ->
-                    assertSame(views[index++], child)
+        viewGroup.children.forEachIndexed { index, child ->
+                    assertSame(views[index], child)
                 }
     }
 

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -204,8 +204,8 @@ class ViewGroupTest {
         views.forEach { viewGroup.addView(it) }
 
         viewGroup.children.forEachIndexed { index, child ->
-                    assertSame(views[index], child)
-                }
+            assertSame(views[index], child)
+        }
     }
 
     @Test fun setMargins() {

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -199,6 +199,18 @@ class ViewGroupTest {
         }
     }
 
+    @Test fun children() {
+        val views = listOf(View(context), View(context), View(context))
+        views.forEach { viewGroup.addView(it) }
+
+        var index = 0
+        viewGroup
+                .children
+                .forEach { child ->
+                    assertSame(views[index++], child)
+                }
+    }
+
     @Test fun setMargins() {
         val layoutParams = ViewGroup.MarginLayoutParams(100, 200)
         layoutParams.setMargins(42)

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -73,12 +73,8 @@ operator fun ViewGroup.iterator() = object : MutableIterator<View> {
 
 /** Returns a [Sequence] over the child views in this view group. */
 val ViewGroup.children: Sequence<View>
-    get() {
-        var index = -1
-        return generateSequence {
-            index++
-            getChildAt(index)
-        }
+    get() = object: Sequence<View> {
+        override fun iterator() = this@children.iterator()
     }
 
 /**

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -73,7 +73,7 @@ operator fun ViewGroup.iterator() = object : MutableIterator<View> {
 
 /** Returns a [Sequence] over the child views in this view group. */
 val ViewGroup.children: Sequence<View>
-    get() = object: Sequence<View> {
+    get() = object : Sequence<View> {
         override fun iterator() = this@children.iterator()
     }
 

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -71,6 +71,16 @@ operator fun ViewGroup.iterator() = object : MutableIterator<View> {
     override fun remove() = removeViewAt(--index)
 }
 
+/** Returns a [Sequence] over the child views in this view group. */
+val ViewGroup.children: Sequence<View>
+    get() {
+        var index = -1
+        return generateSequence {
+            index++
+            getChildAt(index)
+        }
+    }
+
 /**
  * Sets the margins in the ViewGroup's MarginLayoutParams. This version of the method sets all axes
  * to the provided size.


### PR DESCRIPTION
References #138

Adds a `children` val extension to ViewGroup which returns a Sequence of child views

I'm not too sure about the naming of the test method, so if someone has a better suggestion :pray: 