### PR TITLE
Make doOnLayout check isLayoutRequested()

### DIFF
--- a/src/androidTest/java/androidx/view/ViewTest.kt
+++ b/src/androidTest/java/androidx/view/ViewTest.kt
@@ -21,6 +21,7 @@ import android.support.test.InstrumentationRegistry
 import android.view.View
 import androidx.assertThrows
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -61,6 +62,26 @@ class ViewTest {
         view.doOnLayout {
             called = true
         }
+        assertTrue(called)
+    }
+
+    @Test
+    fun doOnLayoutWhileLayoutRequested() {
+        // First layout the view
+        view.layout(0, 0, 10, 10)
+        // Then later a layout is requested
+        view.requestLayout()
+
+        var called = false
+        view.doOnLayout {
+            called = true
+        }
+
+        // Assert that we haven't been called while the layout pass is pending
+        assertFalse(called)
+
+        // Now layout the view and assert that we're called
+        view.layout(0, 0, 20, 20)
         assertTrue(called)
     }
 

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -42,14 +42,14 @@ inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) {
 }
 
 /**
- * Performs the given action when this view is laid out. If the view has been laid out, the action
- * will be performed straight away, otherwise the action will be performed after the
- * view is laid out.
+ * Performs the given action when this view is laid out. If the view has been laid out and it
+ * has not requested a layout, the action will be performed straight away, otherwise the
+ * action will be performed after the view is next laid out.
  *
  * @see doOnNextLayout
  */
 inline fun View.doOnLayout(crossinline action: (view: View) -> Unit) {
-    if (ViewCompat.isLaidOut(this)) {
+    if (ViewCompat.isLaidOut(this) && !isLayoutRequested) {
         action(this)
     } else {
         doOnNextLayout {


### PR DESCRIPTION
Currently if doOnLayout is called while a layout pass is
pending it will notify synchronously. Since a layout is
pending we should wait for it to complete before notifying.