### PR TITLE
Extensions for startActivity methods

### DIFF
--- a/src/main/java/androidx/app/Activity.kt
+++ b/src/main/java/androidx/app/Activity.kt
@@ -1,0 +1,19 @@
+package androidx.app
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.support.annotation.RequiresApi
+
+/**
+ * Syntactic sugar for [Activity.startActivityForResult(Intent, Int)][Activity.startActivityForResult].
+ */
+inline fun <reified T> Activity.startActivityForResult(code: Int, block: Intent.() -> Unit = {}) =
+        startActivityForResult(Intent(this, T::class.java).apply(block), code)
+
+/**
+ * Syntactic sugar for Activity.startActivityForResult(Intent, Int, Bundle)[Activity.startActivityForResult].
+ */
+@RequiresApi(16)
+inline fun <reified T> Activity.startActivityForResult(code: Int, options: Bundle, block: Intent.() -> Unit = {}) =
+        startActivityForResult(Intent(this, T::class.java).apply(block), code, options)

--- a/src/main/java/androidx/app/Activity.kt
+++ b/src/main/java/androidx/app/Activity.kt
@@ -8,12 +8,12 @@ import android.support.annotation.RequiresApi
 /**
  * Syntactic sugar for [Activity.startActivityForResult(Intent, Int)][Activity.startActivityForResult].
  */
-inline fun <reified T> Activity.startActivityForResult(code: Int, block: Intent.() -> Unit = {}) =
+inline fun <reified T: Activity> Activity.startActivityForResult(code: Int, block: Intent.() -> Unit = {}) =
         startActivityForResult(Intent(this, T::class.java).apply(block), code)
 
 /**
- * Syntactic sugar for Activity.startActivityForResult(Intent, Int, Bundle)[Activity.startActivityForResult].
+ * Syntactic sugar for [Activity.startActivityForResult(Intent, Int, Bundle)][Activity.startActivityForResult].
  */
 @RequiresApi(16)
-inline fun <reified T> Activity.startActivityForResult(code: Int, options: Bundle, block: Intent.() -> Unit = {}) =
+inline fun <reified T: Activity> Activity.startActivityForResult(code: Int, options: Bundle, block: Intent.() -> Unit = {}) =
         startActivityForResult(Intent(this, T::class.java).apply(block), code, options)

--- a/src/main/java/androidx/app/Fragment.kt
+++ b/src/main/java/androidx/app/Fragment.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.app
+
+import android.app.Activity
+import android.app.Fragment
+import android.content.Intent
+import android.os.Bundle
+import android.support.annotation.RequiresApi
+
+/**
+ * Syntactic sugar for [Fragment.startActivityForResult(Intent, Int)][Fragment.startActivityForResult].
+ *
+ * The context used is this fragment's Activity, therefore this method will throw an exception if
+ * the fragment isn't attached.
+ */
+inline fun <reified T: Activity> Fragment.startActivityForResult(code: Int, block: Intent.() -> Unit = {}) =
+    startActivityForResult(Intent(activity, T::class.java).apply(block), code)
+
+/**
+ * Syntactic sugar for [Fragment.startActivityForResult(Intent, Int, Bundle)][Fragment.startActivityForResult].
+ *
+ * The context used is this fragment's Activity, therefore this method will throw an exception if
+ * the fragment isn't attached.
+ */
+@RequiresApi(16)
+inline fun <reified T: Activity> Fragment.startActivityForResult(code: Int, options: Bundle, block: Intent.() -> Unit = {}) =
+    startActivityForResult(Intent(activity, T::class.java).apply(block), code, options)

--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -16,6 +16,7 @@
 
 package androidx.content
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.TypedArray
@@ -97,12 +98,12 @@ inline fun Context.withStyledAttributes(
 /**
  * Syntactic sugar for [Context.startActivity(Intent)][Context.startActivity].
  */
-inline fun <reified T> Context.startActivity(block: Intent.() -> Unit = {}) =
+inline fun <reified T: Activity> Context.startActivity(block: Intent.() -> Unit = {}) =
         startActivity(Intent(this, T::class.java).apply(block))
 
 /**
  * Syntactic sugar for [Context.startActivity(Intent, Bundle)][Context.startActivity].
  */
 @RequiresApi(16)
-inline fun <reified T> Context.startActivity(options: Bundle, block: Intent.() -> Unit = {}) =
+inline fun <reified T: Activity> Context.startActivity(options: Bundle, block: Intent.() -> Unit = {}) =
         startActivity(Intent(this, T::class.java).apply(block), options)

--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -17,7 +17,9 @@
 package androidx.content
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.TypedArray
+import android.os.Bundle
 import android.support.annotation.AttrRes
 import android.support.annotation.RequiresApi
 import android.support.annotation.StyleRes
@@ -91,3 +93,16 @@ inline fun Context.withStyledAttributes(
         typedArray.recycle()
     }
 }
+
+/**
+ * Syntactic sugar for [Context.startActivity(Intent)][Context.startActivity].
+ */
+inline fun <reified T> Context.startActivity(block: Intent.() -> Unit = {}) =
+        startActivity(Intent(this, T::class.java).apply(block))
+
+/**
+ * Syntactic sugar for [Context.startActivity(Intent, Bundle)][Context.startActivity].
+ */
+@RequiresApi(16)
+inline fun <reified T> Context.startActivity(options: Bundle, block: Intent.() -> Unit = {}) =
+        startActivity(Intent(this, T::class.java).apply(block), options)


### PR DESCRIPTION
Adds fluency to be able to start new activities using statements like
```
startActivity<MyActivity>()
startActivity<MyActivity>() {
    putExtra("key", "value")
}
startActivity<MyActivity>(ActivityOptions.makeBasic().toBundle())
```