### PR TITLE
Add private modifier to fix lint warning

### DIFF
--- a/src/androidTest/java/androidx/util/AtomicFileTest.kt
+++ b/src/androidTest/java/androidx/util/AtomicFileTest.kt
@@ -29,7 +29,7 @@ import java.io.IOException
 
 @SdkSuppress(minSdkVersion = 17)
 class AtomicFileTest {
-    @get:Rule val temporaryFolder = TemporaryFolder()
+    @get:Rule private val temporaryFolder = TemporaryFolder()
 
     private lateinit var file: AtomicFile
 


### PR DESCRIPTION
Add private modifier in `AtomicFileTest.kt` to fix lint warning.