### PR TITLE
Add annotation to suppress MemberVisibilityCanPrivate warning

### DIFF
--- a/src/androidTest/java/androidx/util/AtomicFileTest.kt
+++ b/src/androidTest/java/androidx/util/AtomicFileTest.kt
@@ -29,6 +29,7 @@ import java.io.IOException
 
 @SdkSuppress(minSdkVersion = 17)
 class AtomicFileTest {
+    @Suppress("MemberVisibilityCanPrivate")
     @get:Rule val temporaryFolder = TemporaryFolder()
 
     private lateinit var file: AtomicFile


### PR DESCRIPTION
Add annotation to suppress MemberVisibilityCanPrivate warning because JUnit requires this to be public.

ref. #218