### PR TITLE
add File#toUri()

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -320,6 +320,11 @@ package androidx.os {
     method public static final error.NonExistentClass bundleOf(kotlin.Pair<String,?>... pairs);
   }
 
+  public final class FileKt {
+    ctor public FileKt();
+    method public static final android.net.Uri toUri(java.io.File);
+  }
+
   public final class HandlerKt {
     ctor public HandlerKt();
     method public static final error.NonExistentClass postAtTime(android.os.Handler, long uptimeMillis, Object? token = "null", kotlin.jvm.functions.Function0<kotlin.Unit> action);

--- a/src/androidTest/java/androidx/graphics/drawable/IconTest.kt
+++ b/src/androidTest/java/androidx/graphics/drawable/IconTest.kt
@@ -21,10 +21,10 @@ import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.drawable.Icon
-import android.net.Uri
 import android.support.test.InstrumentationRegistry
 import android.support.test.filters.SdkSuppress
 import androidx.graphics.createBitmap
+import androidx.os.toUri
 import okio.Okio.buffer
 import okio.Okio.sink
 import okio.Okio.source
@@ -74,7 +74,7 @@ class IconTest {
                 sink.writeAll(source)
             }
         }
-        val uri = Uri.fromFile(cacheFile)
+        val uri = cacheFile.toUri()
         val icon = uri.toIcon()
 
         val rendered = icon.toIntrinsicBitmap()

--- a/src/androidTest/java/androidx/os/FileTest.kt
+++ b/src/androidTest/java/androidx/os/FileTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.net.Uri
+import android.support.test.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class FileTest {
+    private val context = InstrumentationRegistry.getContext()
+
+    @Test
+    fun uri() {
+        val cacheFile = File(context.cacheDir, "red.png")
+        assertEquals(Uri.fromFile(cacheFile), cacheFile.toUri())
+    }
+}

--- a/src/main/java/androidx/os/File.kt
+++ b/src/main/java/androidx/os/File.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+
+package androidx.os
+
+import android.net.Uri
+import java.io.File
+
+/**
+ * Creates a Uri from the given file.
+ *
+ * @see Uri.parse
+ */
+inline fun File.toUri(): Uri = Uri.fromFile(this)


### PR DESCRIPTION
Another frequent use case of Uri conversion, like String#toUri()