### PR TITLE
Add show/hide extension methods to View for concise alpha animations

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -667,6 +667,8 @@ package androidx.view {
     method public static final android.graphics.Bitmap toBitmap(android.view.View, android.graphics.Bitmap.Config config = "Bitmap.Config.ARGB_8888");
     method public static final void updatePadding(android.view.View, @Px int left = "paddingLeft", @Px int top = "paddingTop", @Px int right = "paddingRight", @Px int bottom = "paddingBottom");
     method @RequiresApi(17) public static final void updatePaddingRelative(android.view.View, @Px int start = "paddingStart", @Px int top = "paddingTop", @Px int end = "paddingEnd", @Px int bottom = "paddingBottom");
+    method @RequiresApi(12) public static final void show(android.view.View, Boolean animated = "true", Long duration = "0.225.toLong()", kotlin.jvm.functions.Function0<kotlin.Unit> onFinished = "null")
+    method @RequiresApi(12) public static final void hide(android.view.View, Boolean animated = "true", Long duration = "0.195.toLong()", kotlin.jvm.functions.Function0<kotlin.Unit> onFinished = "null")
   }
 
 }

--- a/src/androidTest/java/androidx/view/ViewTest.kt
+++ b/src/androidTest/java/androidx/view/ViewTest.kt
@@ -18,7 +18,6 @@ package androidx.view
 
 import android.graphics.Bitmap
 import android.support.test.InstrumentationRegistry
-import android.util.Log
 import android.view.View
 import androidx.assertThrows
 import org.junit.Assert.assertEquals

--- a/src/androidTest/java/androidx/view/ViewTest.kt
+++ b/src/androidTest/java/androidx/view/ViewTest.kt
@@ -18,6 +18,7 @@ package androidx.view
 
 import android.graphics.Bitmap
 import android.support.test.InstrumentationRegistry
+import android.util.Log
 import android.view.View
 import androidx.assertThrows
 import org.junit.Assert.assertEquals
@@ -168,5 +169,19 @@ class ViewTest {
         val bitmap = view.toBitmap(Bitmap.Config.RGB_565)
 
         assertSame(Bitmap.Config.RGB_565, bitmap.config)
+    }
+
+    @Test
+    fun showView() {
+        view.alpha = 0.0f
+        view.show(animate = false)
+        assertEquals(1.0f, view.alpha)
+    }
+
+    @Test
+    fun hideView() {
+        view.alpha = 1.0f
+        view.hide(animate = false)
+        assertEquals(0.0f, view.alpha)
     }
 }

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -16,6 +16,8 @@
 
 package androidx.view
 
+import android.animation.Animator
+import android.animation.Animator.AnimatorListener
 import android.graphics.Bitmap
 import android.support.annotation.Px
 import android.support.annotation.RequiresApi
@@ -171,4 +173,86 @@ fun View.toBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Bitmap {
         throw IllegalStateException("View needs to be laid out before calling toBitmap()")
     }
     return Bitmap.createBitmap(width, height, config).applyCanvas(::draw)
+}
+
+/**
+ * Shows the [View] by setting the alpha to 1.0f.
+ *
+ * Animates the transition by default and has an optional callback when animation is finished.
+ *
+ * @param animate Boolean used to determine whether to animate alpha change.
+ *  If false then 1.0f is just set as the alpha of the [View]. Defaults to true.
+ * @param duration Long used as the duration of the animation if animate parameter is true.
+ *  Ignored if not animating. Defaults to 0.225s, the material design recommendation for elements
+ *  entering the screen.
+ * @param onFinished An lambda that will be called in [AnimatorListener.onAnimationEnd] to alert
+ *  the caller the animation finished. Defaults to null.
+ */
+@RequiresApi(12)
+fun View.show(animate: Boolean = true, duration: Long = 0.225.toLong(), onFinished: (() -> Unit)? = null) {
+    if (animate) {
+        this.animate()
+            .alpha(1.0f)
+            .setListener(object : AnimatorListener {
+                override fun onAnimationStart(animation: Animator?) {
+                    // Ignore
+                }
+
+                override fun onAnimationRepeat(animation: Animator?) {
+                    // Ignore
+                }
+
+                override fun onAnimationEnd(animation: Animator?) {
+                    onFinished?.invoke()
+                }
+
+                override fun onAnimationCancel(animation: Animator?) {
+                    // Ignore
+                }
+            }).duration = duration
+
+    } else {
+        this.alpha = 1.0f
+    }
+}
+
+/**
+ * Hides the [View] by setting the alpha to 0.0f.
+ *
+ * Animates the transition by default and has an optional callback when animation is finished.
+ *
+ * @param animate Boolean used to determine whether to animate alpha change.
+ *  If false then 1.0f is just set as the alpha of the [View]. Defaults to true.
+ * @param duration Long used as the duration of the animation if animate parameter is true.
+ *  Ignored if not animating. Defaults to 0.195s, the material design recommendation for elements
+ *  leaving the screen.
+ * @param onFinished An lambda that will be called in [AnimatorListener.onAnimationEnd] to alert
+ *  the caller the animation finished. Defaults to null.
+ */
+@RequiresApi(12)
+fun View.hide(animate: Boolean = true, duration: Long = 0.195.toLong(), onFinished: (() -> Unit)? = null) {
+    if (animate) {
+        this.animate()
+            .alpha(0.0f)
+            .setListener(object : AnimatorListener {
+                override fun onAnimationStart(animation: Animator?) {
+                    // Ignore
+                }
+
+                override fun onAnimationRepeat(animation: Animator?) {
+                    // Ignore
+                }
+
+                override fun onAnimationEnd(animation: Animator?) {
+                    onFinished?.invoke()
+                }
+
+                override fun onAnimationCancel(animation: Animator?) {
+                    // Ignore
+                }
+            }).duration = duration
+
+    } else {
+        this.alpha = 0.0f
+    }
 }


### PR DESCRIPTION
Animating alpha values is a thing developers will do hundreds of times and while the ViewPropertyAnimator is great and easy to use it would be nice to just be able to `view.show()` to animate to 1.0f alpha.

Since 1.0f and 0.0f are by far the most common alpha values to animate to I believe this would be a handy extension method.

If I missed something or my naming conventions are off please let me know, I would be happy to fix it.

For testing I wanted to add a test for the `onFinished` functionality but articles online told me async tests are controversial so I've erred on the side of simple tests.