### PR TITLE
Bug with SparseArray

### DIFF
--- a/src/androidTest/java/androidx/util/LongSparseArrayTest.kt
+++ b/src/androidTest/java/androidx/util/LongSparseArrayTest.kt
@@ -42,6 +42,16 @@ class LongSparseArrayTest {
         assertTrue(1L in array)
     }
 
+    @Test fun containsOperatorWithValue() {
+        val array = LongSparseArray<String>()
+        array.put(1L, "one")
+
+        assertFalse(2L in array)
+        array.put(2L, "two")
+
+        assertTrue(2L in array)
+    }
+
     @Test fun setOperator() {
         val array = LongSparseArray<String>()
         array[1L] = "one"
@@ -64,6 +74,16 @@ class LongSparseArrayTest {
         assertFalse(array.containsKey(1L))
         array.put(1L, "one")
         assertTrue(array.containsKey(1L))
+    }
+
+    @Test fun containsKeyWithValue() {
+        val array = LongSparseArray<String>()
+        array.put(1L, "one")
+
+        assertFalse(array.containsKey(2L))
+        array.put(2L, "one")
+
+        assertTrue(array.containsKey(2L))
     }
 
     @Test fun containsValue() {

--- a/src/androidTest/java/androidx/util/SparseArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseArrayTest.kt
@@ -40,6 +40,16 @@ class SparseArrayTest {
         assertTrue(1 in array)
     }
 
+    @Test fun containsOperatorWithItem() {
+        val array = SparseArray<String>()
+        array.put(1, "one")
+
+        assertFalse(2 in array)
+        array.put(2, "two")
+
+        assertTrue(2 in array)
+    }
+
     @Test fun setOperator() {
         val array = SparseArray<String>()
         array[1] = "one"

--- a/src/androidTest/java/androidx/util/SparseBooleanArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseBooleanArrayTest.kt
@@ -39,6 +39,16 @@ class SparseBooleanArrayTest {
         assertTrue(1 in array)
     }
 
+    @Test fun containsOperatorWithValue() {
+        val array = SparseBooleanArray()
+        array.put(1, true)
+
+        assertFalse(2 in array)
+        array.put(2, true)
+
+        assertTrue(2 in array)
+    }
+
     @Test fun setOperator() {
         val array = SparseBooleanArray()
         array[1] = true
@@ -61,6 +71,16 @@ class SparseBooleanArrayTest {
         assertFalse(array.containsKey(1))
         array.put(1, true)
         assertTrue(array.containsKey(1))
+    }
+
+    @Test fun containsKeyWithValue() {
+        val array = SparseBooleanArray()
+        array.put(1, true)
+
+        assertFalse(array.containsKey(2))
+        array.put(2, true)
+
+        assertTrue(array.containsKey(2))
     }
 
     @Test fun containsValue() {

--- a/src/androidTest/java/androidx/util/SparseIntArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseIntArrayTest.kt
@@ -39,6 +39,16 @@ class SparseIntArrayTest {
         assertTrue(1 in array)
     }
 
+    @Test fun containsOperatorWithValue() {
+        val array = SparseIntArray()
+        array.put(1, 11)
+
+        assertFalse(2 in array)
+        array.put(2, 22)
+
+        assertTrue(2 in array)
+    }
+
     @Test fun setOperator() {
         val array = SparseIntArray()
         array[1] = 11
@@ -61,6 +71,16 @@ class SparseIntArrayTest {
         assertFalse(array.containsKey(1))
         array.put(1, 11)
         assertTrue(array.containsKey(1))
+    }
+
+    @Test fun containsKeyWithValue() {
+        val array = SparseIntArray()
+        array.put(1, 11)
+
+        assertFalse(array.containsKey(2))
+        array.put(2, 22)
+
+        assertTrue(array.containsKey(2))
     }
 
     @Test fun containsValue() {

--- a/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
@@ -17,7 +17,6 @@
 package androidx.util
 
 import android.support.test.filters.SdkSuppress
-import android.util.SparseIntArray
 import android.util.SparseLongArray
 import androidx.fail
 import com.google.common.truth.Truth.assertThat

--- a/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
+++ b/src/androidTest/java/androidx/util/SparseLongArrayTest.kt
@@ -17,6 +17,7 @@
 package androidx.util
 
 import android.support.test.filters.SdkSuppress
+import android.util.SparseIntArray
 import android.util.SparseLongArray
 import androidx.fail
 import com.google.common.truth.Truth.assertThat
@@ -41,6 +42,16 @@ class SparseLongArrayTest {
         assertTrue(1 in array)
     }
 
+    @Test fun containsOperatorWithValue() {
+        val array = SparseLongArray()
+        array.put(1, 11L)
+
+        assertFalse(2 in array)
+        array.put(2, 22L)
+
+        assertTrue(2 in array)
+    }
+
     @Test fun setOperator() {
         val array = SparseLongArray()
         array[1] = 11L
@@ -63,6 +74,16 @@ class SparseLongArrayTest {
         assertFalse(array.containsKey(1))
         array.put(1, 11L)
         assertTrue(array.containsKey(1))
+    }
+
+    @Test fun containsKeyWithValue() {
+        val array = SparseLongArray()
+        array.put(1, 11L)
+
+        assertFalse(array.containsKey(2))
+        array.put(2, 22L)
+
+        assertTrue(array.containsKey(2))
     }
 
     @Test fun containsValue() {

--- a/src/main/java/androidx/util/LongSparseArray.kt
+++ b/src/main/java/androidx/util/LongSparseArray.kt
@@ -27,7 +27,7 @@ inline val <T> LongSparseArray<T>.size get() = size()
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(16)
-inline operator fun <T> LongSparseArray<T>.contains(key: Long) = indexOfKey(key) != -1
+inline operator fun <T> LongSparseArray<T>.contains(key: Long) = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 @RequiresApi(16)
@@ -44,7 +44,7 @@ operator fun <T> LongSparseArray<T>.plus(other: LongSparseArray<T>): LongSparseA
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.containsKey(key: Long) = indexOfKey(key) != -1
+inline fun <T> LongSparseArray<T>.containsKey(key: Long) = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 @RequiresApi(16)

--- a/src/main/java/androidx/util/SparseArray.kt
+++ b/src/main/java/androidx/util/SparseArray.kt
@@ -24,7 +24,7 @@ import android.util.SparseArray
 inline val <T> SparseArray<T>.size get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun <T> SparseArray<T>.contains(key: Int) = indexOfKey(key) != -1
+inline operator fun <T> SparseArray<T>.contains(key: Int) = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun <T> SparseArray<T>.set(key: Int, value: T) = put(key, value)
@@ -38,7 +38,7 @@ operator fun <T> SparseArray<T>.plus(other: SparseArray<T>): SparseArray<T> {
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun <T> SparseArray<T>.containsKey(key: Int) = indexOfKey(key) != -1
+inline fun <T> SparseArray<T>.containsKey(key: Int) = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 inline fun <T> SparseArray<T>.containsValue(value: T) = indexOfValue(value) != -1

--- a/src/main/java/androidx/util/SparseBooleanArray.kt
+++ b/src/main/java/androidx/util/SparseBooleanArray.kt
@@ -24,7 +24,7 @@ import android.util.SparseBooleanArray
 inline val SparseBooleanArray.size get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun SparseBooleanArray.contains(key: Int) = indexOfKey(key) != -1
+inline operator fun SparseBooleanArray.contains(key: Int) = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun SparseBooleanArray.set(key: Int, value: Boolean) = put(key, value)
@@ -38,7 +38,7 @@ operator fun SparseBooleanArray.plus(other: SparseBooleanArray): SparseBooleanAr
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun SparseBooleanArray.containsKey(key: Int) = indexOfKey(key) != -1
+inline fun SparseBooleanArray.containsKey(key: Int) = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 inline fun SparseBooleanArray.containsValue(value: Boolean) = indexOfValue(value) != -1

--- a/src/main/java/androidx/util/SparseIntArray.kt
+++ b/src/main/java/androidx/util/SparseIntArray.kt
@@ -24,7 +24,7 @@ import android.util.SparseIntArray
 inline val SparseIntArray.size get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun SparseIntArray.contains(key: Int) = indexOfKey(key) != -1
+inline operator fun SparseIntArray.contains(key: Int) = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun SparseIntArray.set(key: Int, value: Int) = put(key, value)
@@ -38,7 +38,7 @@ operator fun SparseIntArray.plus(other: SparseIntArray): SparseIntArray {
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun SparseIntArray.containsKey(key: Int) = indexOfKey(key) != -1
+inline fun SparseIntArray.containsKey(key: Int) = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 inline fun SparseIntArray.containsValue(value: Int) = indexOfValue(value) != -1

--- a/src/main/java/androidx/util/SparseLongArray.kt
+++ b/src/main/java/androidx/util/SparseLongArray.kt
@@ -27,7 +27,7 @@ inline val SparseLongArray.size get() = size()
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(18)
-inline operator fun SparseLongArray.contains(key: Int) = indexOfKey(key) != -1
+inline operator fun SparseLongArray.contains(key: Int) = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 @RequiresApi(18)
@@ -44,7 +44,7 @@ operator fun SparseLongArray.plus(other: SparseLongArray): SparseLongArray {
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(18)
-inline fun SparseLongArray.containsKey(key: Int) = indexOfKey(key) != -1
+inline fun SparseLongArray.containsKey(key: Int) = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 @RequiresApi(18)


### PR DESCRIPTION
If `SparseArray` (or it modification such as `SparseLongArray`) contains an element, then `indexOfKey` function returns `-2`. So the methods `contains` and `containsKey` worked incorrectly 