### PR TITLE
File.toUri() to API 24+

### DIFF
--- a/src/main/java/androidx/os/File.kt
+++ b/src/main/java/androidx/os/File.kt
@@ -20,15 +20,16 @@ package androidx.os
 
 import android.net.Uri
 import java.io.File
-import android.support.v4.content.FileProvider
+import android.support.v4.content.FileProvider.getUriForFile
 import android.content.Context
+import android.support.annotation.RequiresApi
 /**
  * Creates a Uri from the given file
  * Uri.fromFile() throw FileUriExposedException on API 24+
  * @see Uri.parse
  */
 @RequiresApi(24)
-inline fun File.toUri(context: Context, authority: String): Uri = FileProvider.getUriForFile(context, authority, this)
+inline fun File.toUri(context: Context, authority: String): Uri = getUriForFile(context, authority, this)
 
 /**
  * Creates a Uri from the given file.

--- a/src/main/java/androidx/os/File.kt
+++ b/src/main/java/androidx/os/File.kt
@@ -20,6 +20,15 @@ package androidx.os
 
 import android.net.Uri
 import java.io.File
+import android.support.v4.content.FileProvider
+import android.content.Context
+/**
+ * Creates a Uri from the given file
+ * Uri.fromFile() throw FileUriExposedException on API 24+
+ * @see Uri.parse
+ */
+@RequiresApi(24)
+inline fun File.toUri(context: Context, authority: String): Uri = FileProvider.getUriForFile(context, authority, this)
 
 /**
  * Creates a Uri from the given file.


### PR DESCRIPTION
Uri.fromFile() throw FileUriExposedException on API 24+