### PR TITLE
Add Int.dp.

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -36,6 +36,11 @@ package androidx.content {
 
 package androidx.content.res {
 
+  public final class ResourcesKt {
+    ctor public ResourcesKt();
+    method public static final int getDp(int);
+  }
+
   public final class TypedArrayKt {
     ctor public TypedArrayKt();
     method public static final boolean getBooleanOrThrow(android.content.res.TypedArray, @StyleableRes int index);

--- a/src/androidTest/java/androidx/content/res/ResourcesTest.kt
+++ b/src/androidTest/java/androidx/content/res/ResourcesTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.content.res
+
+import android.support.test.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResourcesTest {
+    private val context = InstrumentationRegistry.getContext()
+
+    @Test fun dpToPx() {
+        assertEquals(16.dp, (context.resources.displayMetrics.density * 16).toInt())
+    }
+}

--- a/src/main/java/androidx/content/res/Resources.kt
+++ b/src/main/java/androidx/content/res/Resources.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.content.res
+
+import android.content.res.Resources
+
+/**
+ * Convert density independent pixels into pixels.
+ *
+ * This simplifies code dealing with dimensions.
+ * ```
+ * view.updatePadding(top = 16.dp)
+ * ```
+ */
+inline val Int.dp: Int
+    get() = (this * Resources.getSystem().displayMetrics.density).toInt()


### PR DESCRIPTION
An extension property that converts an integer of dp into px, allowing for calls such as
```kotlin
view.updatePadding(top = 16.dp)
```
Few points that are probably worth discussing:
- Are there any issues with statically accessing `Resources` with `Resources.getSystem()`?
- Should this be a property or a method?
- Should this return an `Int` or a `Float`? Android's APIs sometimes require one or the other. I've personally found `Int` to be more useful during day-to-day dev.