### PR TITLE
Add extensions for starting service

### DIFF
--- a/src/androidTest/AndroidManifest.xml
+++ b/src/androidTest/AndroidManifest.xml
@@ -2,5 +2,7 @@
           package="androidx.kotlin">
     <application>
         <activity android:name=".TestActivity"/>
+
+        <service android:name=".TestService"/>
     </application>
 </manifest>

--- a/src/androidTest/java/androidx/kotlin/TestService.kt
+++ b/src/androidTest/java/androidx/kotlin/TestService.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.kotlin
+
+import android.app.Service
+import android.content.Intent
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class TestService : Service() {
+
+    override fun onCreate() {
+        super.onCreate()
+        isRunning.set(true)
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        startIntent.set(intent)
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onBind(intent: Intent) = Binder(intent)
+
+    override fun onDestroy() {
+        super.onDestroy()
+        isRunning.set(false)
+        startIntent.set(null)
+    }
+
+    companion object {
+
+        val startIntent = AtomicReference<Intent?>(null)
+        val isRunning = AtomicBoolean()
+    }
+
+    class Binder(
+        val intent: Intent
+    ) : android.os.Binder()
+}

--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -16,7 +16,11 @@
 
 package androidx.content
 
+import android.app.Service
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
 import android.content.res.TypedArray
 import android.support.annotation.AttrRes
 import android.support.annotation.RequiresApi
@@ -90,4 +94,30 @@ inline fun Context.withStyledAttributes(
     } finally {
         typedArray.recycle()
     }
+}
+
+/**
+ * Starts the [Service] with an intent which is passed as receiver to [initializer] block
+ *
+ * @see [Context.startService]
+ */
+inline fun <reified T : Service> Context.startService(
+    initializer: Intent.() -> Unit = {}
+): ComponentName {
+    val intent = Intent(this, T::class.java).apply(initializer)
+    return startService(intent)
+}
+
+/**
+ * Binds the [Service] with an intent which is passed as receiver to [initializer] block
+ *
+ * @see [Context.bindService]
+ */
+inline fun <reified T : Service> Context.bindService(
+    connection: ServiceConnection,
+    flags: Int = Context.BIND_AUTO_CREATE,
+    initializer: Intent.() -> Unit = {}
+): Boolean {
+    val intent = Intent(this, T::class.java).apply(initializer)
+    return bindService(intent, connection, flags)
 }


### PR DESCRIPTION
Add extensions for start/bind `Service` which can be used in following way:
```kotlin
startService<MyService>()
startService<MyService> {
    action = "action"
}

bindService<MyService>(connection)
bindService<MyService>(connection, flags = 0)
bindService<MyService>(connection, flags = 0) { 
    action = "action"
}
```