### PR TITLE
Add `use` extension function to Bitmap

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -104,6 +104,7 @@ package androidx.graphics {
     method public static final operator int get(android.graphics.Bitmap, int x, int y);
     method public static final android.graphics.Bitmap scale(android.graphics.Bitmap, int width, int height, boolean filter = "true");
     method public static final operator void set(android.graphics.Bitmap, int x, int y, @ColorInt int color);
+    method public static final <T> T! use(android.graphics.Bitmap, kotlin.jvm.functions.Function1<? super android.graphics.Bitmap,? extends T> block);
   }
 
   public final class CanvasKt {

--- a/src/androidTest/java/androidx/graphics/BitmapTest.kt
+++ b/src/androidTest/java/androidx/graphics/BitmapTest.kt
@@ -20,6 +20,7 @@ import android.graphics.Bitmap
 import android.graphics.ColorSpace
 import android.support.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BitmapTest {
@@ -67,5 +68,17 @@ class BitmapTest {
         val b = createBitmap(2, 2)
         b[1, 1] = 0x40302010
         assertEquals(0x40302010, b[1, 1])
+    }
+
+    @Test fun use() {
+        val bitmap = createBitmap(1, 1)
+
+        var called = false
+        bitmap.use {
+            called = true
+        }
+
+        assertTrue(called)
+        assertTrue(bitmap.isRecycled)
     }
 }

--- a/src/main/java/androidx/graphics/Bitmap.kt
+++ b/src/main/java/androidx/graphics/Bitmap.kt
@@ -111,3 +111,13 @@ inline fun createBitmap(
 ): Bitmap {
     return Bitmap.createBitmap(width, height, config, hasAlpha, colorSpace)
 }
+
+/**
+ * Executes the given [block] function on this Bitmap and then recycles it
+ *
+ * @see kotlin.io.use
+ * @see Bitmap.recycle
+ */
+inline fun <T> Bitmap.use(block: (Bitmap) -> T): T {
+    return block(this).also { recycle() }
+}


### PR DESCRIPTION
Similar to other Closeable's and can be used in following way:
```kotlin
createBitmap(10, 10).use { bitmap ->
    doSomething()
}
```