### PR TITLE
Add boolean getter extensions to Cursor

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -65,6 +65,9 @@ package androidx.database {
     method public static final byte[] getBlob(android.database.Cursor, String columnName);
     method public static final byte[]? getBlobOrNull(android.database.Cursor, int index);
     method public static final error.NonExistentClass getBlobOrNull(android.database.Cursor, String columnName);
+    method public static final boolean getBoolean(android.database.Cursor, String columnName);
+    method public static final Boolean? getBooleanOrNull(android.database.Cursor, int index);
+    method public static final error.NonExistentClass getBooleanOrNull(android.database.Cursor, String columnName);
     method public static final double getDouble(android.database.Cursor, String columnName);
     method public static final Double? getDoubleOrNull(android.database.Cursor, int index);
     method public static final error.NonExistentClass getDoubleOrNull(android.database.Cursor, String columnName);

--- a/src/androidTest/java/androidx/database/CursorTest.kt
+++ b/src/androidTest/java/androidx/database/CursorTest.kt
@@ -66,6 +66,12 @@ class CursorTest {
         assertEquals("hey", string)
     }
 
+    @Test fun booleanByName() {
+        val cursor = scalarCursor(1)
+        val boolean = cursor.getBoolean("data")
+        assertEquals(true, boolean)
+    }
+
     @Test fun blobOrNullByIndex() {
         val cursor = scalarCursor(null)
         val blob = cursor.getBlobOrNull(0)
@@ -108,6 +114,12 @@ class CursorTest {
         assertNull(string)
     }
 
+    @Test fun booleanOrNullByIndex() {
+        val cursor = scalarCursor(null)
+        val boolean = cursor.getBooleanOrNull(0)
+        assertNull(boolean)
+    }
+
     @Test fun blobOrNullByName() {
         val cursor = scalarCursor(null)
         val blob = cursor.getBlobOrNull("data")
@@ -148,6 +160,12 @@ class CursorTest {
         val cursor = scalarCursor(null)
         val string = cursor.getStringOrNull("data")
         assertNull(string)
+    }
+
+    @Test fun booleanOrNullByName() {
+        val cursor = scalarCursor(null)
+        val boolean = cursor.getBooleanOrNull("data")
+        assertNull(boolean)
     }
 
     private fun scalarCursor(item: Any?): Cursor = MatrixCursor(arrayOf("data")).apply {

--- a/src/main/java/androidx/database/Cursor.kt
+++ b/src/main/java/androidx/database/Cursor.kt
@@ -101,6 +101,18 @@ inline fun Cursor.getString(columnName: String): String =
     getString(getColumnIndexOrThrow(columnName))
 
 /**
+ * Returns the value of the requested column as a boolean.
+ *
+ * The result and whether this method throws an exception when the column value is null or the
+ * column type is not an integral type is implementation-defined.
+ *
+ * @see Cursor.getColumnIndexOrThrow
+ * @see Cursor.getInt
+ */
+inline fun Cursor.getBoolean(columnName: String): Boolean =
+    getInt(getColumnIndexOrThrow(columnName)) == 1
+
+/**
  * Returns the value of the requested column as a nullable byte array.
  *
  * The result and whether this method throws an exception when the column type is not a blob type is
@@ -176,6 +188,17 @@ inline fun Cursor.getShortOrNull(index: Int) = if (isNull(index)) null else getS
  * @see Cursor.getString
  */
 inline fun Cursor.getStringOrNull(index: Int) = if (isNull(index)) null else getString(index)
+
+/**
+ * Returns the value of the requested column as a nullable boolean.
+ *
+ * The result and whether this method throws an exception when the column type is not an integral
+ * type is implementation-defined.
+ *
+ * @see Cursor.isNull
+ * @see Cursor.getInt
+ */
+inline fun Cursor.getBooleanOrNull(index: Int) = if (isNull(index)) null else getInt(index) == 1
 
 /**
  * Returns the value of the requested column as a nullable byte array.
@@ -267,3 +290,16 @@ inline fun Cursor.getShortOrNull(columnName: String) =
  */
 inline fun Cursor.getStringOrNull(columnName: String) =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getString(it) }
+
+/**
+ * Returns the value of the requested column as a nullable boolean.
+ *
+ * The result and whether this method throws an exception when the column type is not an integral
+ * type is implementation-defined.
+ *
+ * @see Cursor.getColumnIndexOrThrow
+ * @see Cursor.isNull
+ * @see Cursor.getString
+ */
+inline fun Cursor.getBooleanOrNull(columnName: String) =
+    getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getInt(it) == 1 }


### PR DESCRIPTION
there is a way to put boolean into the sqlite database like

`db.insert("table", null, contentValuesOf("booleanColumn" to true))`

or

`db.update("table", contentValuesOf("booleanColumn" to true), null, null)`

but there is no native function to get a boolean from a cursor.

therefore it would be nice to have some boolean getter extensions like

`cursor.getBoolean("booleanColumn")`

or

`cursor.getBooleanOrNull("booleanColumn")`