### PR TITLE
Add ViewGroup extension to allow concisely modifying of the layoutParams

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -660,6 +660,7 @@ package androidx.view {
     method public static final operator void minusAssign(android.view.ViewGroup, android.view.View view);
     method public static final operator void plusAssign(android.view.ViewGroup, android.view.View view);
     method public static final void setMargins(android.view.ViewGroup.MarginLayoutParams, @Px int size);
+    method public static final void updateLayoutParams(android.view.ViewGroup, kotlin.jvm.functions.Function1<? super android.view.ViewGroup.LayoutParams,kotlin.Unit> block);
     method public static final void updateMargins(android.view.ViewGroup.MarginLayoutParams, @Px int left = "leftMargin", @Px int top = "topMargin", @Px int right = "rightMargin", @Px int bottom = "bottomMargin");
     method @RequiresApi(17) public static final void updateMarginsRelative(android.view.ViewGroup.MarginLayoutParams, @Px int start = "marginStart", @Px int top = "topMargin", @Px int end = "marginEnd", @Px int bottom = "bottomMargin");
   }

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -209,9 +209,9 @@ class ViewGroupTest {
         }
     }
 
-    @Test fun layoutParamsAs() {
-        viewGroup.layoutParams = LinearLayout.LayoutParams(0, 0)
-        viewGroup.layoutParamsAs<LinearLayout.LayoutParams> {
+    @Test fun updateLayoutParams() {
+        viewGroup.layoutParams = ViewGroup.LayoutParams(0, 0)
+        viewGroup.updateLayoutParams {
             assertSame(viewGroup.layoutParams, this)
 
             width = 500
@@ -220,9 +220,20 @@ class ViewGroupTest {
 
         assertEquals(500, viewGroup.layoutParams.width)
         assertEquals(1000, viewGroup.layoutParams.height)
+    }
+
+    @Test fun updateLayoutParamsAs() {
+        viewGroup.layoutParams = LinearLayout.LayoutParams(0, 0)
+        viewGroup.updateLayoutParamsAs<LinearLayout.LayoutParams> {
+            assertSame(viewGroup.layoutParams, this)
+
+            weight = 2f
+        }
+
+        assertEquals(2f, (viewGroup.layoutParams as LinearLayout.LayoutParams).weight)
 
         assertThrows<ClassCastException> {
-            viewGroup.layoutParamsAs<RelativeLayout.LayoutParams> {}
+            viewGroup.updateLayoutParamsAs<RelativeLayout.LayoutParams> {}
         }
     }
 

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -21,6 +21,7 @@ import android.support.test.filters.SdkSuppress
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import androidx.assertThrows
 import androidx.fail
 import com.google.common.truth.Truth.assertThat
@@ -205,6 +206,23 @@ class ViewGroupTest {
 
         viewGroup.children.forEachIndexed { index, child ->
             assertSame(views[index], child)
+        }
+    }
+
+    @Test fun layoutParamsAs() {
+        viewGroup.layoutParams = LinearLayout.LayoutParams(0, 0)
+        viewGroup.layoutParamsAs<LinearLayout.LayoutParams> {
+            assertSame(viewGroup.layoutParams, this)
+
+            width = 500
+            height = 1000
+        }
+
+        assertEquals(500, viewGroup.layoutParams.width)
+        assertEquals(1000, viewGroup.layoutParams.height)
+
+        assertThrows<ClassCastException> {
+            viewGroup.layoutParamsAs<RelativeLayout.LayoutParams> {}
         }
     }
 

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -78,6 +78,21 @@ val ViewGroup.children: Sequence<View>
     }
 
 /**
+ * Executes [block] with a typed version of the ViewGroup's layoutParams and reassigns the
+ * layoutParams with the updated version.
+ *
+ * @see ViewGroup.getLayoutParams
+ * @see ViewGroup.setLayoutParams
+ **/
+inline fun <reified T> ViewGroup.layoutParamsAs(
+    block: T.() -> Unit
+) where T : ViewGroup.LayoutParams {
+    val typedLayoutParams = layoutParams as T
+    block(typedLayoutParams)
+    layoutParams = typedLayoutParams
+}
+
+/**
  * Sets the margins in the ViewGroup's MarginLayoutParams. This version of the method sets all axes
  * to the provided size.
  *

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -78,13 +78,23 @@ val ViewGroup.children: Sequence<View>
     }
 
 /**
+ * Executes [block] with the layoutParams and reassigns the layoutParams with the updated version.
+ *
+ * @see ViewGroup.getLayoutParams
+ * @see ViewGroup.setLayoutParams
+ **/
+inline fun ViewGroup.updateLayoutParams(block: ViewGroup.LayoutParams.() -> Unit) {
+    updateLayoutParamsAs(block)
+}
+
+/**
  * Executes [block] with a typed version of the ViewGroup's layoutParams and reassigns the
  * layoutParams with the updated version.
  *
  * @see ViewGroup.getLayoutParams
  * @see ViewGroup.setLayoutParams
  **/
-inline fun <reified T> ViewGroup.layoutParamsAs(
+inline fun <reified T> ViewGroup.updateLayoutParamsAs(
     block: T.() -> Unit
 ) where T : ViewGroup.LayoutParams {
     val typedLayoutParams = layoutParams as T


### PR DESCRIPTION
Added ViewGroup extension to allow concisely modifying of the layoutParams.

This allows following usage:
```
viewGroup.layoutParamsAs<ViewGroup.MarginLayoutParams> {
    updateMarginsRelative(start = marginStart)
}
```

Instead of:
```
val marginLayoutParams = viewGroup.layoutParams as ViewGroup.MarginLayoutParams
marginLayoutParams.updateMarginsRelative(start = 16)
viewGroup.layoutParams = marginLayoutParams
```

Was unable to update the `api` due to reified generics issue https://github.com/android/android-ktx/issues/235.