### PR TITLE
Api version check methods

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -317,6 +317,12 @@ package androidx.net {
 
 package androidx.os {
 
+  public final class BuildKt {
+    ctor public BuildKt();
+    method public static final void fromApi(int fromVersion, kotlin.jvm.functions.Function0<kotlin.Unit> block);
+    method public static final void toApi(int toVersion, kotlin.jvm.functions.Function0<kotlin.Unit> block);
+  }
+
   public final class BundleKt {
     ctor public BundleKt();
     method public static final error.NonExistentClass bundleOf(kotlin.Pair<String,?>... pairs);

--- a/src/androidTest/java/androidx/os/BuildTest.kt
+++ b/src/androidTest/java/androidx/os/BuildTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.os.Build
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BuildTest {
+
+    companion object {
+        /* Used to restore sdk version after all tests in this class have passed */
+        private val sdkVersion = Build.VERSION.SDK_INT
+
+        @AfterClass @JvmStatic fun afterAll() {
+            setSdkVersion(sdkVersion)
+        }
+
+        /* Used to stub sdk version */
+        private fun setSdkVersion(version: Int) {
+            Build.VERSION::class.java.getField("SDK_INT")?.let {
+                it.isAccessible = true
+
+                it.setInt(this, version)
+            }
+        }
+    }
+
+    @Test
+    fun fromApi() {
+        var name: String? = null
+
+        setSdkVersion(15)
+        fromApi(16, {
+            name = "ICE_CREAM_SANDWICH_MR1"
+        })
+        assertNull(name)
+
+        setSdkVersion(16)
+        fromApi(16, {
+            name = "ICE_CREAM_SANDWICH_MR1"
+        })
+        assertEquals(name, "ICE_CREAM_SANDWICH_MR1")
+    }
+
+    @Test
+    fun toApi() {
+        var name: String? = null
+
+        setSdkVersion(21)
+        toApi(21, {
+            name = "KIT_KAT"
+        })
+        assertNull(name)
+
+        setSdkVersion(19)
+        toApi(21, {
+            name = "KIT_KAT"
+        })
+        assertEquals(name, "KIT_KAT")
+    }
+}

--- a/src/main/java/androidx/os/Build.kt
+++ b/src/main/java/androidx/os/Build.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.os.Build
+
+/**
+ * Executes a [block] prior to a given android sdk version [toVersion] **exclusive**
+ *
+ * ```
+ * toApi(19, {
+ *     // Do something...
+ * })
+ * ```
+ */
+inline fun toApi(toVersion: Int, block: () -> Unit) {
+    if (Build.VERSION.SDK_INT < toVersion) block()
+}
+
+/**
+ * Executes a [block] following a given android sdk version [fromVersion] **inclusive**
+ *
+ * ```
+ * fromApi(21, {
+ *     // Do something...
+ * })
+ * ```
+ */
+inline fun fromApi(fromVersion: Int, block: () -> Unit) {
+    if (Build.VERSION.SDK_INT >= fromVersion) block()
+}


### PR DESCRIPTION
A couple of convenient methods to execute some actions for specific api versions

```Kotlin
fromApi(21, {
    // Do something...
})
```

Not sure about inclusive/exclusive cases though. Should they be supplied as arguments?