### PR TITLE
Add delegate extension for three reference type

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -96,6 +96,30 @@ package androidx.database.sqlite {
 
 }
 
+package androidx.delegate {
+
+  public final class PhantomRef<T> implements kotlin.properties.ReadWriteProperty<java.lang.Object,T> {
+    ctor public PhantomRef(T? p, java.lang.ref.ReferenceQueue<T> queue);
+    method public T? getValue(Object? thisRef, kotlin.reflect.KProperty<?> property);
+    method public void setValue(Object? thisRef, kotlin.reflect.KProperty<?> property, T? value);
+  }
+
+  public final class SoftRef<T> implements kotlin.properties.ReadWriteProperty<java.lang.Object,T> {
+    ctor public SoftRef(T? p, java.lang.ref.ReferenceQueue<T>? queue);
+    ctor public SoftRef();
+    method public T? getValue(Object? thisRef, kotlin.reflect.KProperty<?> property);
+    method public void setValue(Object? thisRef, kotlin.reflect.KProperty<?> property, T? value);
+  }
+
+  public final class WeakRef<T> implements kotlin.properties.ReadWriteProperty<java.lang.Object,T> {
+    ctor public WeakRef(T? p, java.lang.ref.ReferenceQueue<T>? queue);
+    ctor public WeakRef();
+    method public T? getValue(Object? thisRef, kotlin.reflect.KProperty<?> property);
+    method public void setValue(Object? thisRef, kotlin.reflect.KProperty<?> property, T? value);
+  }
+
+}
+
 package androidx.graphics {
 
   public final class BitmapKt {

--- a/src/androidTest/java/androidx/delegate/ReferenceTest.kt
+++ b/src/androidTest/java/androidx/delegate/ReferenceTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.delegate
+
+import android.support.test.filters.SdkSuppress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.lang.ref.ReferenceQueue
+
+@SdkSuppress(minSdkVersion = 19)
+class ReferenceTest {
+    @Test fun assignSoftReference() {
+        var variable by SoftRef("foo")
+        assertEquals("foo", variable)
+        variable = "bar"
+        assertNotEquals("foo", variable)
+        assertEquals("bar", variable)
+    }
+
+    @Test fun notAssignSoftReference() {
+        var variable by SoftRef<Int>()
+        assertNull(variable)
+        variable = 11
+        assertNotNull(variable)
+        assertEquals(11, variable)
+    }
+
+    @Test fun gcSoftReference() {
+        var data: TestData? = TestData()
+        val variable by SoftRef(data)
+        assertNotNull(variable)
+        data = null
+        System.gc()
+        assertNotNull(variable)
+    }
+
+    @Test fun assignWeakReference() {
+        var variable by WeakRef("foo")
+        assertEquals("foo", variable)
+        variable = "bar"
+        assertNotEquals("foo", variable)
+        assertEquals("bar", variable)
+    }
+
+    @Test fun notAssignWeakReference() {
+        var variable by WeakRef<String>()
+        assertNull(variable)
+        variable = "bar"
+        assertNotNull(variable)
+        assertEquals("bar", variable)
+    }
+
+    @Test fun gcWeakReference() {
+        val variable by WeakRef(TestData())
+        System.gc()
+        assertNull(variable)
+    }
+
+    @Test fun assignPhantomReference() {
+        var variable by PhantomRef("foo", ReferenceQueue())
+        assertNull(variable)
+    }
+
+    @Test fun notAssignPhantomReference() {
+        var variable by PhantomRef<String>(queue = ReferenceQueue())
+        assertNull(variable)
+    }
+
+    private data class TestData(var id: Int = 0)
+}

--- a/src/main/java/androidx/delegate/Reference.kt
+++ b/src/main/java/androidx/delegate/Reference.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.delegate
+
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.SoftReference
+import java.lang.ref.WeakReference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Wrap the [SoftReference] by kotlin delegate. Don't have to use [get]/[set] method
+ * for accessing or assigning a variable each of times.
+ *
+ * ```
+ * val data by SoftRef(TestData())
+ * ```
+ */
+class SoftRef<T>(
+    default: T? = null,
+    private val queue: ReferenceQueue<T>? = null
+) : ReadWriteProperty<Any?, T?> {
+    private var variable: SoftReference<T>?
+
+    init {
+        variable = initSoftReference(default, queue)
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? = variable?.get()
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        variable = initSoftReference(value, queue)
+    }
+
+    private fun initSoftReference(value: T? = null, queue: ReferenceQueue<T>? = null) =
+        value?.run {
+            queue?.let { SoftReference(this, it) } ?: SoftReference(this)
+        }
+}
+
+/**
+ * Wrap the [WeakReference] by kotlin delegate. Don't have to use [get]/[set] method
+ * for accessing or assigning a variable each of times.
+ *
+ * ```
+ * val data by SoftRef(TestData())
+ * ```
+ */
+class WeakRef<T>(
+    default: T? = null,
+    private val queue: ReferenceQueue<T>? = null
+) : ReadWriteProperty<Any?, T?> {
+    private var variable: WeakReference<T>?
+
+    init {
+        variable = initWeakReference(default, queue)
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? = variable?.get()
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        variable = initWeakReference(value, queue)
+    }
+
+    private fun initWeakReference(value: T? = null, queue: ReferenceQueue<T>? = null) =
+        value?.run {
+            queue?.let { WeakReference(this, it) } ?: WeakReference(this)
+        }
+}
+
+/**
+ * Wrap the [PhantomReference] by kotlin delegate. Don't have to use [get]/[set] method
+ * for accessing or assigning a variable each of times.
+ *
+ * ```
+ * val data by SoftRef(TestData())
+ * ```
+ */
+class PhantomRef<T>(
+    default: T? = null,
+    private val queue: ReferenceQueue<T>
+) : ReadWriteProperty<Any?, T?> {
+    private var variable: PhantomReference<T>?
+
+    init {
+        variable = default?.let { PhantomReference(it, queue) }
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? = variable?.get()
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        variable = value?.let { PhantomReference(it, queue) }
+    }
+}


### PR DESCRIPTION
Added three delegate classes for `SoftReference`, `WeakReference`, and `PhantomReference`.

The usage as the following:

```kotlin
val variable by SoftRef(TestData())
val variable by WeakRef(TestData())
val variable by PhantomRef(TestData())
```