### PR TITLE
Add `MarginLayoutParams` extensions for destructuring

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -648,6 +648,10 @@ package androidx.view {
 
   public final class ViewGroupKt {
     ctor public ViewGroupKt();
+    method public static final operator int component1(android.view.ViewGroup.MarginLayoutParams);
+    method public static final operator int component2(android.view.ViewGroup.MarginLayoutParams);
+    method public static final operator int component3(android.view.ViewGroup.MarginLayoutParams);
+    method public static final operator int component4(android.view.ViewGroup.MarginLayoutParams);
     method public static final operator boolean contains(android.view.ViewGroup, android.view.View view);
     method public static final void forEach(android.view.ViewGroup, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static final void forEachIndexed(android.view.ViewGroup, kotlin.jvm.functions.Function2<? super Integer,? super android.view.View,kotlin.Unit> action);

--- a/src/androidTest/java/androidx/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/view/ViewGroupTest.kt
@@ -261,4 +261,19 @@ class ViewGroupTest {
         assertEquals(10, layoutParams.marginStart)
         assertEquals(30, layoutParams.marginEnd)
     }
+
+    @Test fun destructuringMarginLayoutParams() {
+        val (l, t, r, b) = ViewGroup.MarginLayoutParams(100, 100).apply {
+            updateMargins(
+                left = 4,
+                top = 8,
+                right = 16,
+                bottom = 24
+            )
+        }
+        assertEquals(4, l)
+        assertEquals(8, t)
+        assertEquals(16, r)
+        assertEquals(24, b)
+    }
 }

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -120,3 +120,47 @@ fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
     marginEnd = end
     bottomMargin = bottom
 }
+
+/**
+ * Returns "leftMargin", the first component of the [MarginLayoutParams].
+ *
+ * This method allows to use destructuring declarations when working with [MarginLayoutParams],
+ * for example:
+ * ```
+ * val (left, top, right, bottom) = marginLayoutParams
+ * ```
+ */
+inline operator fun ViewGroup.MarginLayoutParams.component1() = this.leftMargin
+
+/**
+ * Returns "topMargin", the second component of the [MarginLayoutParams].
+ *
+ * This method allows to use destructuring declarations when working with [MarginLayoutParams],
+ * for example:
+ * ```
+ * val (left, top, right, bottom) = marginLayoutParams
+ * ```
+ */
+inline operator fun ViewGroup.MarginLayoutParams.component2() = this.topMargin
+
+/**
+ * Returns "rightMargin", the third component of the [MarginLayoutParams].
+ *
+ * This method allows to use destructuring declarations when working with [MarginLayoutParams],
+ * for example:
+ * ```
+ * val (left, top, right, bottom) = marginLayoutParams
+ * ```
+ */
+inline operator fun ViewGroup.MarginLayoutParams.component3() = this.rightMargin
+
+/**
+ * Returns "bottomMargin", the fourth component of the [MarginLayoutParams].
+ *
+ * This method allows to use destructuring declarations when working with [MarginLayoutParams],
+ * for example:
+ * ```
+ * val (left, top, right, bottom) = marginLayoutParams
+ * ```
+ */
+inline operator fun ViewGroup.MarginLayoutParams.component4() = this.bottomMargin


### PR DESCRIPTION
Having the idea that `MarginLayoutParams` are commonly used for dealing with margins, I thought it might be useful to have destructuring extensions for this, so it could be used like:
```Kotlin
val (left, top, right, bottom) = marginLayoutParams
```

I'm not sure how to deal with `marginEnd`/`marginStart` though. Should we have an sdk version check in place, to decide whether we should return `marginStart` or `leftMargin` ?