### PR TITLE
Disable lint warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ android {
 
     lintOptions {
         checkTestSources true
+        ignoreWarnings true
     }
 
     // TODO replace with https://issuetracker.google.com/issues/72050365 once released.


### PR DESCRIPTION
Since we're running lint on test code, they're needlessly noisy.

Closes #292. Closes #303.