### PR TITLE
Extension: Append query parameters to uri via multi Pair values.

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -19,13 +19,12 @@
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
           <option name="IMPORT_NESTED_CLASSES" value="true" />
           <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-          <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="false" />
           <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="false" />
           <option name="CONTINUATION_INDENT_FOR_CHAINED_CALLS" value="false" />
-          <option name="CONTINUATION_INDENT_IN_SUPERTYPE_LISTS" value="false" />
-          <option name="CONTINUATION_INDENT_IN_IF_CONDITIONS" value="false" />
-          <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
         </JetCodeStyleSettings>
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <Objective-C-extensions>
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
@@ -61,8 +60,6 @@
           <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
           <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
           <option name="EXTENDS_LIST_WRAP" value="1" />
-          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-          <option name="ASSIGNMENT_WRAP" value="1" />
         </codeStyleSettings>
       </value>
     </option>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -19,12 +19,13 @@
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
           <option name="IMPORT_NESTED_CLASSES" value="true" />
           <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+          <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="false" />
           <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="false" />
           <option name="CONTINUATION_INDENT_FOR_CHAINED_CALLS" value="false" />
+          <option name="CONTINUATION_INDENT_IN_SUPERTYPE_LISTS" value="false" />
+          <option name="CONTINUATION_INDENT_IN_IF_CONDITIONS" value="false" />
+          <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
         </JetCodeStyleSettings>
-        <MarkdownNavigatorCodeStyleSettings>
-          <option name="RIGHT_MARGIN" value="72" />
-        </MarkdownNavigatorCodeStyleSettings>
         <Objective-C-extensions>
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
@@ -60,6 +61,8 @@
           <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
           <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
           <option name="EXTENDS_LIST_WRAP" value="1" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+          <option name="ASSIGNMENT_WRAP" value="1" />
         </codeStyleSettings>
       </value>
     </option>

--- a/api/current.txt
+++ b/api/current.txt
@@ -310,6 +310,7 @@ package androidx.net {
 
   public final class UriKt {
     ctor public UriKt();
+    method public static final android.net.Uri.Builder appendQueryParameters(android.net.Uri.Builder, kotlin.Pair<String,java.lang.String>... values);
     method public static final android.net.Uri toUri(String);
   }
 

--- a/src/androidTest/java/androidx/net/UriTest.kt
+++ b/src/androidTest/java/androidx/net/UriTest.kt
@@ -21,14 +21,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class UriTest {
-    @Test
-    fun uri() {
+    @Test fun uri() {
         val string = "https://test.example.com/foo?bar#baz"
         assertEquals(Uri.parse(string), string.toUri())
     }
 
-    @Test
-    fun appendQueryParameters() {
+    @Test fun appendQueryParameters() {
         val uri1 = Uri.parse("https://test.example.com/foo")
         val appendUri1 = uri1.buildUpon().appendQueryParameters(
                 "key1" to "value1",

--- a/src/androidTest/java/androidx/net/UriTest.kt
+++ b/src/androidTest/java/androidx/net/UriTest.kt
@@ -21,8 +21,26 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class UriTest {
-    @Test fun uri() {
+    @Test
+    fun uri() {
         val string = "https://test.example.com/foo?bar#baz"
         assertEquals(Uri.parse(string), string.toUri())
+    }
+
+    @Test
+    fun appendQueryParameters() {
+        val uri1 = Uri.parse("https://test.example.com/foo")
+        val appendUri1 = uri1.buildUpon().appendQueryParameters(
+                "key1" to "value1",
+                "key2" to "value2"
+        ).build()
+        assertEquals("$uri1?key1=value1&key2=value2", appendUri1.toString())
+
+        val uri2 = Uri.parse("https://test.example.com/foo?key1=value1")
+        val appendUri2 = uri2.buildUpon().appendQueryParameters(
+                "key2" to "value2"
+        ).build()
+        assertEquals("$uri2&key2=value2", appendUri2.toString())
+
     }
 }

--- a/src/androidTest/java/androidx/net/UriTest.kt
+++ b/src/androidTest/java/androidx/net/UriTest.kt
@@ -39,6 +39,5 @@ class UriTest {
                 "key2" to "value2"
         ).build()
         assertEquals("$uri2&key2=value2", appendUri2.toString())
-
     }
 }

--- a/src/main/java/androidx/net/Uri.kt
+++ b/src/main/java/androidx/net/Uri.kt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("NOTHING_TO_INLINE")
-
-// Aliases to public API.
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
 
 package androidx.net
 

--- a/src/main/java/androidx/net/Uri.kt
+++ b/src/main/java/androidx/net/Uri.kt
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+@file:Suppress("NOTHING_TO_INLINE")
+
+// Aliases to public API.
 
 package androidx.net
 
@@ -26,3 +28,13 @@ import android.net.Uri
  * @see Uri.parse
  */
 inline fun String.toUri(): Uri = Uri.parse(this)
+
+/**
+ * Append query parameters via multi Pair values.
+ */
+fun Uri.Builder.appendQueryParameters(vararg values: Pair<String, String>): Uri.Builder {
+    values.forEach {
+        appendQueryParameter(it.first, it.second)
+    }
+    return this
+}


### PR DESCRIPTION
Add an `appendQueryParameters()` method for `Uri.Builder`.

```kotlin
val uri = Uri.parse("https://test.example.com/foo")
val appendUri = uri.buildUpon().appendQueryParameters(
    "key1" to "value1",
    "key2" to "value2"
    ).build()
```
=>

```
https://test.example.com/foo?key1=value1&key2=value2
```
