### PR TITLE
easier way to use AsyncTask.

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -318,6 +318,21 @@ package androidx.net {
 
 package androidx.os {
 
+  public final class AsyncTaskKTX<Params, Progress, Result> extends android.os.AsyncTask<Params,Progress,Result> {
+    ctor public AsyncTaskKTX();
+    method protected Result! doInBackground(Params... params);
+    method public final android.os.AsyncTask<Params,Progress,Result> runInBackground(kotlin.jvm.functions.Function1<? super androidx.os.AsyncTaskKTX<Params,Progress,Result>.Builder,kotlin.Unit> init);
+  }
+
+  public final class AsyncTaskKTX.Builder {
+    ctor public AsyncTaskKTX.Builder();
+    method public final void doInBg(kotlin.jvm.functions.Function1<? super Params[],? extends Result> background);
+    method public final androidx.os.AsyncTaskKTX<Params,Progress,Result> getAsyncTask();
+    method public final void onPostExecute(kotlin.jvm.functions.Function1<? super Result,kotlin.Unit> action);
+    method public final void onUpdate(kotlin.jvm.functions.Function1<? super Progress[],kotlin.Unit> update);
+    method public final void publishProgress(Progress... values);
+  }
+
   public final class BundleKt {
     ctor public BundleKt();
     method public static final error.NonExistentClass bundleOf(kotlin.Pair<String,?>... pairs);

--- a/src/androidTest/java/androidx/os/AsyncTaskTest.kt
+++ b/src/androidTest/java/androidx/os/AsyncTaskTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.os.AsyncTask
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Created by muhannad on 2/16/18.
+ */
+class AsyncTaskTest {
+
+    @Test
+    fun testtask() {
+        println("main , Thread : ${Thread.currentThread().name}")
+        val execute = AsyncTaskKTX<Int, Int, Int>().runInBackground {
+            doInBg {
+                println("doInBg function in test , Thread : ${Thread.currentThread().name}")
+                Assert.assertEquals(4, it.size)
+                for (i in 1..5) {
+                    Thread.sleep(1000)
+                    publishProgress(i)
+                }
+                it.size
+            }
+            onUpdate {
+                println("onUpdate(${it[0]}) in test , Thread : ${Thread.currentThread().name}")
+            }
+        }.execute(3, 4, 5, 6)
+
+        while (execute.status != AsyncTask.Status.FINISHED) { }
+        Assert.assertEquals(AsyncTask.Status.FINISHED, execute.status)
+    } }

--- a/src/main/java/androidx/os/AsyncTask.kt
+++ b/src/main/java/androidx/os/AsyncTask.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.os
+
+import android.os.AsyncTask
+/**
+ * Created by muhannad on 2/13/18.
+ */
+
+class AsyncTaskKTX<Params, Progress, Result> : AsyncTask<Params, Progress, Result>() {
+    private lateinit var backgroundAction: (Array<out Params>) -> Result
+    private var updateAction: (Array<out Progress>) -> Unit = {}
+    private var postExcuteAction: (Result) -> Unit = {}
+
+    override fun doInBackground(vararg params: Params): Result {
+        return backgroundAction(params)
+    }
+
+    override fun onProgressUpdate(vararg values: Progress) {
+        super.onProgressUpdate(*values)
+        updateAction(values)
+    }
+
+    override fun onPostExecute(result: Result) {
+        super.onPostExecute(result)
+        postExcuteAction(result)
+    }
+
+    fun runInBackground(init: Builder.() -> Unit): AsyncTask<Params, Progress, Result> {
+        val build = Builder()
+        build.init()
+        return this
+    }
+
+    inner class Builder {
+
+        fun onUpdate(update: (Array<out Progress>) -> Unit) {
+            updateAction = update
+        }
+
+        fun doInBg(background: (Array<out Params>) -> Result) {
+            backgroundAction = background
+        }
+
+        fun onPostExecute(action: (Result) -> Unit) {
+            postExcuteAction = action
+        }
+
+        fun publishProgress(vararg values: Progress) {
+            this@AsyncTaskKTX.publishProgress(*values)
+        }
+
+        fun getAsyncTask() = this@AsyncTaskKTX
+    }
+}


### PR DESCRIPTION
easier way to use async task without the need of extending AsyncTask . see #301 
Usage:

```
val execute = AsyncTaskKTX<Int, Int, Int>().runInBackground {
        doInBg {
            //executed in background
        }
        onUpdate {

        }
        onPostExecute {

        }
    }.execute(3, 4, 5, 6)

```