### PR TITLE
Add overload for a single span.

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -358,6 +358,7 @@ package androidx.text {
     method public static android.text.SpannedString buildSpannedString(kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
     method public static android.text.SpannableStringBuilder color(android.text.SpannableStringBuilder, @ColorInt int color, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
     method public static android.text.SpannableStringBuilder inSpans(android.text.SpannableStringBuilder, Object[] spans, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
+    method public static android.text.SpannableStringBuilder inSpans(android.text.SpannableStringBuilder, Object span, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
     method public static android.text.SpannableStringBuilder italic(android.text.SpannableStringBuilder, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
     method public static android.text.SpannableStringBuilder scale(android.text.SpannableStringBuilder, float proportion, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);
     method public static android.text.SpannableStringBuilder strikeThrough(android.text.SpannableStringBuilder, kotlin.jvm.functions.Function1<? super android.text.SpannableStringBuilder,kotlin.Unit> builderAction);

--- a/src/main/java/androidx/text/SpannableStringBuilder.kt
+++ b/src/main/java/androidx/text/SpannableStringBuilder.kt
@@ -57,6 +57,23 @@ inline fun SpannableStringBuilder.inSpans(
 }
 
 /**
+ * Wrap appended text in `builderAction` in `span`.
+ *
+ * Note: the span will only have the correct position if the `builderAction` only appends or
+ * replaces text. Inserting, deleting, or clearing the text will cause the span to be placed at
+ * an incorrect position.
+ */
+inline fun SpannableStringBuilder.inSpans(
+    span: Any,
+    builderAction: SpannableStringBuilder.() -> Unit
+): SpannableStringBuilder {
+    val start = length
+    builderAction()
+    setSpan(span, start, length, SPAN_INCLUSIVE_EXCLUSIVE)
+    return this
+}
+
+/**
  * Wrap appended text in `builderAction` in a bold [StyleSpan].
  *
  * @see SpannableStringBuilder.inSpans


### PR DESCRIPTION
This makes the generated code much more efficient for the common case (a single span) as it avoids the varargs array allocation and loop.