### PR TITLE
Mark some trivial view-related methods as inline.

### DIFF
--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to other public API.
+
 package androidx.view
 
 import android.graphics.Bitmap
@@ -82,7 +84,7 @@ inline fun View.doOnPreDraw(crossinline action: (view: View) -> Unit) {
  * @see View.setPaddingRelative
  */
 @RequiresApi(17)
-fun View.updatePaddingRelative(
+inline fun View.updatePaddingRelative(
     @Px start: Int = paddingStart,
     @Px top: Int = paddingTop,
     @Px end: Int = paddingEnd,
@@ -97,7 +99,7 @@ fun View.updatePaddingRelative(
  *
  * @see View.setPadding
  */
-fun View.updatePadding(
+inline fun View.updatePadding(
     @Px left: Int = paddingLeft,
     @Px top: Int = paddingTop,
     @Px right: Int = paddingRight,
@@ -111,7 +113,7 @@ fun View.updatePadding(
  *
  * @see View.setPadding
  */
-fun View.setPadding(@Px size: Int) {
+inline fun View.setPadding(@Px size: Int) {
     setPadding(size, size, size, size)
 }
 
@@ -127,10 +129,10 @@ fun View.setPadding(@Px size: Int) {
  *
  * @return the created Runnable
  */
-fun View.postDelayed(delayInMillis: Long, action: () -> Unit): Runnable {
-    return Runnable(action).apply {
-        postDelayed(this, delayInMillis)
-    }
+inline fun View.postDelayed(delayInMillis: Long, crossinline action: () -> Unit): Runnable {
+    val runnable = Runnable { action() }
+    postDelayed(runnable, delayInMillis)
+    return runnable
 }
 
 /**
@@ -146,10 +148,13 @@ fun View.postDelayed(delayInMillis: Long, action: () -> Unit): Runnable {
  * @return the created Runnable
  */
 @RequiresApi(16)
-fun View.postOnAnimationDelayed(delayInMillis: Long, action: () -> Unit): Runnable {
-    return Runnable(action).apply {
-        postOnAnimationDelayed(this, delayInMillis)
-    }
+inline fun View.postOnAnimationDelayed(
+    delayInMillis: Long,
+    crossinline action: () -> Unit
+): Runnable {
+    val runnable = Runnable { action() }
+    postOnAnimationDelayed(runnable, delayInMillis)
+    return runnable
 }
 
 /**

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -83,7 +83,7 @@ val ViewGroup.children: Sequence<View>
  *
  * @see ViewGroup.MarginLayoutParams.setMargins
  */
-fun ViewGroup.MarginLayoutParams.setMargins(@Px size: Int) {
+inline fun ViewGroup.MarginLayoutParams.setMargins(@Px size: Int) {
     setMargins(size, size, size, size)
 }
 
@@ -93,7 +93,7 @@ fun ViewGroup.MarginLayoutParams.setMargins(@Px size: Int) {
  *
  * @see ViewGroup.MarginLayoutParams.setMargins
  */
-fun ViewGroup.MarginLayoutParams.updateMargins(
+inline fun ViewGroup.MarginLayoutParams.updateMargins(
     @Px left: Int = leftMargin,
     @Px top: Int = topMargin,
     @Px right: Int = rightMargin,
@@ -109,7 +109,7 @@ fun ViewGroup.MarginLayoutParams.updateMargins(
  * @see ViewGroup.MarginLayoutParams.setMargins
  */
 @RequiresApi(17)
-fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
+inline fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
     @Px start: Int = marginStart,
     @Px top: Int = topMargin,
     @Px end: Int = marginEnd,


### PR DESCRIPTION
The lambdas were creating anonymous types at the callsite already. They were then wrapped in a Runnable inside the method before being posted. By inling and changing the lambda to crossinline, the anonymous type becomes itself a Runnable which can be posted directly.