### PR TITLE
Add AccountManager.removeAccount() that works on all platforms

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -1,3 +1,12 @@
+package androidx.accounts {
+
+  public final class AccountManagerExt {
+    ctor public AccountManagerExt();
+    method public static void removeAccount(android.accounts.AccountManager, android.accounts.Account account, android.app.Activity? activity = "null", android.os.Handler? handler = "null", kotlin.jvm.functions.Function1<? super android.accounts.AccountManagerFuture<android.os.Bundle>,kotlin.Unit>? callback = "null");
+  }
+
+}
+
 package androidx.animation {
 
   public final class AnimatorKt {

--- a/src/androidTest/AndroidManifest.xml
+++ b/src/androidTest/AndroidManifest.xml
@@ -2,5 +2,12 @@
           package="androidx.kotlin">
     <application>
         <activity android:name=".TestActivity"/>
+
+        <service android:name="androidx.accounts.TestAccountAuthenticatorService">
+            <intent-filter>
+                <action android:name="android.accounts.AccountAuthenticator" />
+            </intent-filter>
+            <meta-data android:name="android.accounts.AccountAuthenticator" android:resource="@xml/account_authenticator" />
+        </service>
     </application>
 </manifest>

--- a/src/androidTest/java/androidx/accounts/AccountManagerTest.kt
+++ b/src/androidTest/java/androidx/accounts/AccountManagerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.accounts
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.support.test.InstrumentationRegistry
+import androidx.kotlin.test.R
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@SuppressLint("MissingPermission")
+class AccountManagerTest {
+
+    private val context = InstrumentationRegistry.getContext()
+
+    private val accountManager = AccountManager.get(context)
+
+    private val accountType = context.getString(R.string.account_type)
+
+    private val account1 = Account("Account 1", accountType)
+    private val account2 = Account("Account 2", accountType)
+
+    @After fun after() {
+        accountManager.getAccountsByType(accountType).forEach {
+            accountManager.removeAccountExplicitly(it)
+        }
+    }
+
+    @Test fun testRemoveAccount() {
+        accountManager.addAccountExplicitly(account1, "password", Bundle.EMPTY)
+        accountManager.addAccountExplicitly(account2, "password", Bundle.EMPTY)
+
+        assertEquals(
+            "2 Accounts have been added",
+            2,
+            accountManager.getAccountsByType(accountType).size
+        )
+
+        accountManager.removeAccount(account1) { accountManagerFuture ->
+            assertTrue(
+                "Account removal successful",
+                accountManagerFuture.result.getBoolean(AccountManager.KEY_BOOLEAN_RESULT)
+            )
+
+            assertEquals(
+                "1 Account has been removed",
+                1,
+                accountManager.getAccountsByType(accountType).size
+            )
+        }
+    }
+}

--- a/src/androidTest/java/androidx/accounts/TestAccountAuthenticator.kt
+++ b/src/androidTest/java/androidx/accounts/TestAccountAuthenticator.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.accounts
+
+import android.accounts.AbstractAccountAuthenticator
+import android.accounts.Account
+import android.accounts.AccountAuthenticatorResponse
+import android.accounts.NetworkErrorException
+import android.content.Context
+import android.os.Bundle
+
+class TestAccountAuthenticator(context: Context) : AbstractAccountAuthenticator(context) {
+
+    @Throws(NetworkErrorException::class)
+    override fun addAccount(
+        response: AccountAuthenticatorResponse,
+        accountType: String,
+        authTokenType: String?,
+        requiredFeatures: Array<String>?,
+        options: Bundle
+    ): Bundle? {
+        return null
+    }
+
+    @Throws(NetworkErrorException::class)
+    override fun getAuthToken(
+        response: AccountAuthenticatorResponse,
+        account: Account,
+        authTokenType: String,
+        options: Bundle
+    ): Bundle? {
+        return null
+    }
+
+    override fun getAuthTokenLabel(authTokenType: String): String? {
+        return null
+    }
+
+    @Throws(NetworkErrorException::class)
+    override fun confirmCredentials(
+        response: AccountAuthenticatorResponse,
+        account: Account,
+        options: Bundle?
+    ): Bundle? {
+        return null
+    }
+
+    @Throws(NetworkErrorException::class)
+    override fun updateCredentials(
+        response: AccountAuthenticatorResponse,
+        account: Account,
+        authTokenType: String?,
+        options: Bundle?
+    ): Bundle? {
+        return null
+    }
+
+    @Throws(NetworkErrorException::class)
+    override fun hasFeatures(
+        response: AccountAuthenticatorResponse,
+        account: Account,
+        features: Array<String>
+    ): Bundle? {
+        return null
+    }
+
+    override fun editProperties(
+        response: AccountAuthenticatorResponse?,
+        accountType: String?
+    ): Bundle? {
+        return null
+    }
+}

--- a/src/androidTest/java/androidx/accounts/TestAccountAuthenticatorService.kt
+++ b/src/androidTest/java/androidx/accounts/TestAccountAuthenticatorService.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.accounts
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class TestAccountAuthenticatorService : Service() {
+
+    private lateinit var accountAuthenticator: TestAccountAuthenticator
+
+    override fun onCreate() {
+        accountAuthenticator = TestAccountAuthenticator(this)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return accountAuthenticator.iBinder
+    }
+}

--- a/src/androidTest/res/xml/account_authenticator.xml
+++ b/src/androidTest/res/xml/account_authenticator.xml
@@ -15,10 +15,7 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string-array name="text_array">
-        <item>Hello</item>
-        <item>World</item>
-    </string-array>
-    <string name="account_type">androidx.accounts</string>
-</resources>
+<account-authenticator
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accountType="@string/account_type"
+    />

--- a/src/main/java/androidx/accounts/AccountManager.kt
+++ b/src/main/java/androidx/accounts/AccountManager.kt
@@ -1,0 +1,117 @@
+@file:JvmName("AccountManagerExt")
+
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.accounts
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.accounts.AccountManagerFuture
+import android.accounts.OperationCanceledException
+import android.accounts.AuthenticatorException
+import android.app.Activity
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.support.annotation.RequiresPermission
+import androidx.os.bundleOf
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Removes an account from the AccountManager. Does nothing if the account
+ * does not exist.  Does not delete the account from the server.
+ * The authenticator may have its own policies preventing account
+ * deletion, in which case the account will not be deleted.
+ *
+ * <p>This method may be called from any thread, but the returned
+ * {@link AccountManagerFuture} must not be used on the main thread.
+ *
+ * <p>This method requires the caller to have a signature match with the
+ * authenticator that manages the specified account.
+ *
+ * <p><b>NOTE:</b> If targeting your app to work on API level 22 and before,
+ * MANAGE_ACCOUNTS permission is needed for those platforms. See docs for
+ * this function in API level 22.
+ *
+ *
+ * In API 22 (LOLLIPOP_MR1),
+ * AccountManager.removeAccount(Account, Activity, AccountManagerCallback<Bundle>, Handler) was added, and
+ * AccountManager.removeAccount(Account, AccountManagerCallback<Boolean>, Handler) was deprecated.
+ *
+ * To resolve this when running on a pre-22 device, call the old removeAccount(), get the Boolean result,
+ * put it in a Bundle using key AccountManager.KEY_BOOLEAN_RESULT,
+ * then call AccountManagerCallback<Bundle> callback.run() with a new AccountManagerFuture<Bundle>
+ * that returns this Bundle.
+ *
+ *
+ * @param account The {@link Account} to remove
+ * @param activity The {@link Activity} context to use for launching a new
+ *     authenticator-defined sub-Activity to prompt the user to delete an
+ *     account; used only to call startActivity(); if null, the prompt
+ *     will not be launched directly, but the {@link Intent} may be
+ *     returned to the caller instead
+ * @param handler {@link Handler} identifying the callback thread,
+ *     null for the main thread
+ * @param callback Callback to invoke when the request completes,
+ *     null for no callback
+ */
+@RequiresPermission("android.permission.MANAGE_ACCOUNTS")
+fun AccountManager.removeAccount(
+    account: Account,
+    activity: Activity? = null,
+    handler: Handler? = null,
+    callback: ((AccountManagerFuture<Bundle>) -> Unit)? = null
+) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        removeAccount(account, activity, callback, handler)
+    } else {
+        @Suppress("DEPRECATION")
+        removeAccount(
+            account,
+            { future ->
+                callback?.invoke(object : AccountManagerFuture<Bundle> {
+                    override fun cancel(mayInterruptIfRunning: Boolean) =
+                        future.cancel(mayInterruptIfRunning)
+
+                    override fun isCancelled() = future.isCancelled
+
+                    override fun isDone() = future.isDone
+
+                    @Throws(
+                        OperationCanceledException::class,
+                        IOException::class,
+                        AuthenticatorException::class
+                    )
+                    override fun getResult() = bundleOf(
+                        AccountManager.KEY_BOOLEAN_RESULT to future.result
+                    )
+
+                    @Throws(
+                        OperationCanceledException::class,
+                        IOException::class,
+                        AuthenticatorException::class
+                    )
+                    override fun getResult(timeout: Long, unit: TimeUnit) = bundleOf(
+                        AccountManager.KEY_BOOLEAN_RESULT to future.getResult(timeout, unit)
+                    )
+                })
+            },
+            handler
+        )
+    }
+}


### PR DESCRIPTION
In API 22 (LOLLIPOP_MR1),
AccountManager.removeAccount(Account, Activity, AccountManagerCallback<Bundle>, Handler) was added, and
AccountManager.removeAccount(Account, AccountManagerCallback<Boolean>, Handler) was deprecated.

To resolve this when running on a pre-22 device, call the old removeAccount(), get the Boolean result,
put it in a Bundle using key AccountManager.KEY_BOOLEAN_RESULT,
then call AccountManagerCallback<Bundle> callback.run() with a new AccountManagerFuture<Bundle>
that returns this Bundle.

Credit also to my co-workers @joshfriend and @scottschmitz at @MichiganLabs for their contributions.