### PR TITLE
Add View.announceForAccessibility with String res as parameter

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -722,6 +722,7 @@ package androidx.view {
 
   public final class ViewKt {
     ctor public ViewKt();
+    method @RequiresApi(16) public static void announceForAccessibility(android.view.View, @StringRes int resource);
     method public static void doOnLayout(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static void doOnNextLayout(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);
     method public static void doOnPreDraw(android.view.View, kotlin.jvm.functions.Function1<? super android.view.View,kotlin.Unit> action);

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -25,6 +25,7 @@ import android.support.annotation.StringRes
 import android.support.v4.view.ViewCompat
 import android.view.View
 import android.view.ViewTreeObserver
+import android.view.accessibility.AccessibilityEvent
 import androidx.graphics.applyCanvas
 
 /**
@@ -86,7 +87,7 @@ inline fun View.doOnPreDraw(crossinline action: (view: View) -> Unit) {
 }
 
 /**
- * Sends {@link AccessibilityEvent} of type {@link AccessibilityEvent#TYPE_ANNOUNCEMENT}.
+ * Sends [AccessibilityEvent] of type [AccessibilityEvent.TYPE_ANNOUNCEMENT].
  *
  * @see View.announceForAccessibility
  */

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -21,6 +21,7 @@ package androidx.view
 import android.graphics.Bitmap
 import android.support.annotation.Px
 import android.support.annotation.RequiresApi
+import android.support.annotation.StringRes
 import android.support.v4.view.ViewCompat
 import android.view.View
 import android.view.ViewTreeObserver
@@ -82,6 +83,17 @@ inline fun View.doOnPreDraw(crossinline action: (view: View) -> Unit) {
             return true
         }
     })
+}
+
+/**
+ * Sends {@link AccessibilityEvent} of type {@link AccessibilityEvent#TYPE_ANNOUNCEMENT}.
+ *
+ * @see View.announceForAccessibility
+ */
+@RequiresApi(16)
+inline fun View.announceForAccessibility(@StringRes resource: Int) {
+    val announcement = resources.getString(resource)
+    announceForAccessibility(announcement)
 }
 
 /**


### PR DESCRIPTION
There's an API on View which allows announcements passing `CharSequence`, but not a `@StringResource` - this just delegates.

Not sure how to add a test for this one, but happy to try if you have ideas.