### PR TITLE
Add `startActivity` and `startService` extension

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -14,6 +14,18 @@ package androidx.animation {
 
 }
 
+package androidx.app {
+
+  public final class ActivityKt {
+    ctor public ActivityKt();
+  }
+
+  public final class FragmentKt {
+    ctor public FragmentKt();
+  }
+
+}
+
 package androidx.content {
 
   public final class ContentValuesKt {
@@ -25,6 +37,10 @@ package androidx.content {
     ctor public ContextKt();
     method public static void withStyledAttributes(android.content.Context, android.util.AttributeSet? set = "null", int[] attrs, @AttrRes int defStyleAttr = "0", @StyleRes int defStyleRes = "0", kotlin.jvm.functions.Function1<? super android.content.res.TypedArray,kotlin.Unit> block);
     method public static void withStyledAttributes(android.content.Context, @StyleRes int resourceId, int[] attrs, kotlin.jvm.functions.Function1<? super android.content.res.TypedArray,kotlin.Unit> block);
+  }
+
+  public final class IntentKt {
+    ctor public IntentKt();
   }
 
   public final class SharedPreferencesKt {

--- a/src/androidTest/java/androidx/content/IntentTest.kt
+++ b/src/androidTest/java/androidx/content/IntentTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.content
+
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+import android.support.test.InstrumentationRegistry
+import androidx.kotlin.TestActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IntentTest {
+    private val context = InstrumentationRegistry.getContext()
+
+    @Test fun emptyIntent() {
+        val intent = context.intentOf<TestActivity>()
+        assertTrue(intent.extras.isEmpty)
+    }
+
+    @Test fun intentWithExtras() {
+        val intent = context.intentOf<TestActivity>(EXTRA_STRING to "Hello world!", EXTRA_INT to 12)
+        assertFalse(intent.extras.isEmpty)
+        assertEquals(intent.getStringExtra(EXTRA_STRING), "Hello world!")
+        assertEquals(intent.getIntExtra(EXTRA_INT, Int.MIN_VALUE), 12)
+    }
+
+    @Test fun customIntent() {
+        val intent = context.intentOf<TestActivity> {
+            flags = FLAG_ACTIVITY_CLEAR_TOP
+            addCategory(CATEGORY_EXAMPLE)
+        }
+        assertTrue(intent.extras.isEmpty)
+        assertEquals(intent.flags, FLAG_ACTIVITY_CLEAR_TOP)
+        assertTrue(intent.hasCategory(CATEGORY_EXAMPLE))
+    }
+
+    private companion object {
+        const val EXTRA_STRING = "EXTRA_STRING"
+        const val EXTRA_INT = "EXTRA_INT"
+        const val CATEGORY_EXAMPLE = "CATEGORY_EXAMPLE"
+    }
+}

--- a/src/main/java/androidx/app/Activity.kt
+++ b/src/main/java/androidx/app/Activity.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.app
+
+import android.app.Activity
+import android.content.Intent
+import androidx.content.intentOf
+
+/**
+ * Launch a new activity [T] for which you would like a result when it finished.
+ *
+ * @param requestCode code that will be returned in [Activity.onActivityResult].
+ * @param pairs extended data to the intent
+ * @param init custom intent initialization block
+ */
+inline fun <reified T> Activity.startActivityForResult(
+    requestCode: Int,
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+) = startActivityForResult(intentOf<T>(*pairs, init = init), requestCode)

--- a/src/main/java/androidx/app/Fragment.kt
+++ b/src/main/java/androidx/app/Fragment.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.app
+
+import android.app.Fragment
+import android.content.Intent
+import androidx.content.intentOf
+
+/**
+ * Launch a new activity [T].
+ *
+ * @param pairs extended data to the intent
+ * @param init custom intent initialization block
+ */
+inline fun <reified T> Fragment.startActivity(
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+) = startActivity(activity.intentOf<T>(*pairs, init = init))
+
+/**
+ * Launch a new activity [T] for which you would like a result when it finished.
+ *
+ * @param requestCode code that will be returned in [Fragment.onActivityResult].
+ * @param pairs extended data to the intent
+ * @param init custom intent initialization block
+ */
+inline fun <reified T> Fragment.startActivityForResult(
+    requestCode: Int,
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+) = startActivityForResult(activity.intentOf<T>(*pairs, init = init), requestCode)

--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -17,11 +17,34 @@
 package androidx.content
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.TypedArray
 import android.support.annotation.AttrRes
 import android.support.annotation.RequiresApi
 import android.support.annotation.StyleRes
 import android.util.AttributeSet
+
+/**
+ * Launch a new activity [T].
+ *
+ * @param pairs extended data to the intent
+ * @param init custom intent initialization block
+ */
+inline fun <reified T> Context.startActivity(
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+) = startActivity(intentOf<T>(*pairs, init = init))
+
+/**
+ * Request a service [T] to be started.
+ *
+ * @param pairs extended data to the intent
+ * @param init custom intent initialization block
+ */
+inline fun <reified T> Context.startService(
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+) = startService(intentOf<T>(*pairs, init = init))
 
 /**
  * Return the handle to a system-level service by class.

--- a/src/main/java/androidx/content/Intent.kt
+++ b/src/main/java/androidx/content/Intent.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.content
+
+import android.content.Context
+import android.content.Intent
+import androidx.os.bundleOf
+
+/** Build an intent given extended data and custom initialization block. */
+@PublishedApi
+internal inline fun <reified T> Context.intentOf(
+    vararg pairs: Pair<String, Any?>,
+    noinline init: (Intent.() -> Unit)? = null
+): Intent {
+    val intent = Intent(this, T::class.java)
+    intent.putExtras(bundleOf(*pairs))
+    init?.invoke(intent)
+    return intent
+}


### PR DESCRIPTION
It shorten

```kotlin
startActivity(Intent(this, NextActivity::class.java)
    .putExtra(EXTRA_STRING, "Hello world")
    .putExtra(EXTRA_INT, 12))
```

to `startActivity<NextActivity>(EXTRA_STRING to "Hello world", EXTRA_INT to 12)`.

Although I'm not that sure these are necessary, what do you think?