### PR TITLE
Always specify return type

### DIFF
--- a/src/main/java/androidx/animation/Animator.kt
+++ b/src/main/java/androidx/animation/Animator.kt
@@ -17,6 +17,8 @@
 package androidx.animation
 
 import android.animation.Animator
+import android.animation.Animator.AnimatorListener
+import android.animation.Animator.AnimatorPauseListener
 import android.support.annotation.RequiresApi
 
 /**
@@ -25,7 +27,8 @@ import android.support.annotation.RequiresApi
  * @return the [Animator.AnimatorListener] added to the Animator
  * @see Animator.end
  */
-fun Animator.doOnEnd(action: (animator: Animator) -> Unit) = addListener(onEnd = action)
+fun Animator.doOnEnd(action: (animator: Animator) -> Unit): AnimatorListener =
+    addListener(onEnd = action)
 
 /**
  * Add an action which will be invoked when the animation has started.
@@ -33,7 +36,8 @@ fun Animator.doOnEnd(action: (animator: Animator) -> Unit) = addListener(onEnd =
  * @return the [Animator.AnimatorListener] added to the Animator
  * @see Animator.start
  */
-fun Animator.doOnStart(action: (animator: Animator) -> Unit) = addListener(onStart = action)
+fun Animator.doOnStart(action: (animator: Animator) -> Unit): AnimatorListener =
+    addListener(onStart = action)
 
 /**
  * Add an action which will be invoked when the animation has been cancelled.
@@ -41,13 +45,15 @@ fun Animator.doOnStart(action: (animator: Animator) -> Unit) = addListener(onSta
  * @return the [Animator.AnimatorListener] added to the Animator
  * @see Animator.cancel
  */
-fun Animator.doOnCancel(action: (animator: Animator) -> Unit) = addListener(onCancel = action)
+fun Animator.doOnCancel(action: (animator: Animator) -> Unit): AnimatorListener =
+    addListener(onCancel = action)
 
 /**
  * Add an action which will be invoked when the animation has repeated.
  * @return the [Animator.AnimatorListener] added to the Animator
  */
-fun Animator.doOnRepeat(action: (animator: Animator) -> Unit) = addListener(onRepeat = action)
+fun Animator.doOnRepeat(action: (animator: Animator) -> Unit): AnimatorListener =
+    addListener(onRepeat = action)
 
 /**
  * Add an action which will be invoked when the animation has resumed after a pause.
@@ -56,7 +62,8 @@ fun Animator.doOnRepeat(action: (animator: Animator) -> Unit) = addListener(onRe
  * @see Animator.resume
  */
 @RequiresApi(19)
-fun Animator.doOnResume(action: (animator: Animator) -> Unit) = addPauseListener(onResume = action)
+fun Animator.doOnResume(action: (animator: Animator) -> Unit): AnimatorPauseListener =
+    addPauseListener(onResume = action)
 
 /**
  * Add an action which will be invoked when the animation has been paused.
@@ -65,7 +72,8 @@ fun Animator.doOnResume(action: (animator: Animator) -> Unit) = addPauseListener
  * @see Animator.pause
  */
 @RequiresApi(19)
-fun Animator.doOnPause(action: (animator: Animator) -> Unit) = addPauseListener(onPause = action)
+fun Animator.doOnPause(action: (animator: Animator) -> Unit): AnimatorPauseListener =
+    addPauseListener(onPause = action)
 
 /**
  * Add a listener to this Animator using the provided actions.

--- a/src/main/java/androidx/content/ContentValues.kt
+++ b/src/main/java/androidx/content/ContentValues.kt
@@ -23,23 +23,24 @@ import android.content.ContentValues
  *
  * @throws IllegalArgumentException When a value is not a supported type of [ContentValues].
  */
-fun contentValuesOf(vararg pairs: Pair<String, Any?>) = ContentValues(pairs.size).apply {
-    for ((key, value) in pairs) {
-        when (value) {
-            null -> putNull(key)
-            is String -> put(key, value)
-            is Int -> put(key, value)
-            is Long -> put(key, value)
-            is Boolean -> put(key, value)
-            is Float -> put(key, value)
-            is Double -> put(key, value)
-            is ByteArray -> put(key, value)
-            is Byte -> put(key, value)
-            is Short -> put(key, value)
-            else -> {
-                val valueType = value.javaClass.canonicalName
-                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+fun contentValuesOf(vararg pairs: Pair<String, Any?>): ContentValues =
+    ContentValues(pairs.size).apply {
+        for ((key, value) in pairs) {
+            when (value) {
+                null -> putNull(key)
+                is String -> put(key, value)
+                is Int -> put(key, value)
+                is Long -> put(key, value)
+                is Boolean -> put(key, value)
+                is Float -> put(key, value)
+                is Double -> put(key, value)
+                is ByteArray -> put(key, value)
+                is Byte -> put(key, value)
+                is Short -> put(key, value)
+                else -> {
+                    val valueType = value.javaClass.canonicalName
+                    throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+                }
             }
         }
     }
-}

--- a/src/main/java/androidx/content/Context.kt
+++ b/src/main/java/androidx/content/Context.kt
@@ -34,7 +34,7 @@ import android.util.AttributeSet
  */
 @RequiresApi(23)
 @Suppress("HasPlatformType") // Intentionally propagating platform type with unknown nullability.
-inline fun <reified T> Context.systemService() = getSystemService(T::class.java)
+inline fun <reified T> Context.systemService(): T = getSystemService(T::class.java)
 
 /**
  * Executes [block] on a [TypedArray] receiver. The [TypedArray] holds the attribute

--- a/src/main/java/androidx/content/res/TypedArray.kt
+++ b/src/main/java/androidx/content/res/TypedArray.kt
@@ -228,8 +228,4 @@ fun TypedArray.getTextArrayOrThrow(@StyleableRes index: Int): Array<CharSequence
  *
  * @see kotlin.io.use
  */
-inline fun <R> TypedArray.use(block: (TypedArray) -> R): R {
-    return block(this).also {
-        recycle()
-    }
-}
+inline fun <R> TypedArray.use(block: (TypedArray) -> R): R = block(this).also { recycle() }

--- a/src/main/java/androidx/database/Cursor.kt
+++ b/src/main/java/androidx/database/Cursor.kt
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-@file:Suppress("NOTHING_TO_INLINE") // Aliases to other public API.
+@file:Suppress("NOTHING_TO_INLINE")
+
+// Aliases to other public API.
 
 package androidx.database
 
@@ -109,7 +111,8 @@ inline fun Cursor.getString(columnName: String): String =
  * @see Cursor.isNull
  * @see Cursor.getBlob
  */
-inline fun Cursor.getBlobOrNull(index: Int) = if (isNull(index)) null else getBlob(index)
+inline fun Cursor.getBlobOrNull(index: Int): ByteArray? =
+    if (isNull(index)) null else getBlob(index)
 
 /**
  * Returns the value of the requested column as a nullable double.
@@ -120,7 +123,8 @@ inline fun Cursor.getBlobOrNull(index: Int) = if (isNull(index)) null else getBl
  * @see Cursor.isNull
  * @see Cursor.getDouble
  */
-inline fun Cursor.getDoubleOrNull(index: Int) = if (isNull(index)) null else getDouble(index)
+inline fun Cursor.getDoubleOrNull(index: Int): Double? =
+    if (isNull(index)) null else getDouble(index)
 
 /**
  * Returns the value of the requested column as a nullable float.
@@ -131,7 +135,7 @@ inline fun Cursor.getDoubleOrNull(index: Int) = if (isNull(index)) null else get
  * @see Cursor.isNull
  * @see Cursor.getFloat
  */
-inline fun Cursor.getFloatOrNull(index: Int) = if (isNull(index)) null else getFloat(index)
+inline fun Cursor.getFloatOrNull(index: Int): Float? = if (isNull(index)) null else getFloat(index)
 
 /**
  * Returns the value of the requested column as a nullable integer.
@@ -142,7 +146,7 @@ inline fun Cursor.getFloatOrNull(index: Int) = if (isNull(index)) null else getF
  * @see Cursor.isNull
  * @see Cursor.getInt
  */
-inline fun Cursor.getIntOrNull(index: Int) = if (isNull(index)) null else getInt(index)
+inline fun Cursor.getIntOrNull(index: Int): Int? = if (isNull(index)) null else getInt(index)
 
 /**
  * Returns the value of the requested column as a nullable long.
@@ -153,7 +157,7 @@ inline fun Cursor.getIntOrNull(index: Int) = if (isNull(index)) null else getInt
  * @see Cursor.isNull
  * @see Cursor.getLong
  */
-inline fun Cursor.getLongOrNull(index: Int) = if (isNull(index)) null else getLong(index)
+inline fun Cursor.getLongOrNull(index: Int): Long? = if (isNull(index)) null else getLong(index)
 
 /**
  * Returns the value of the requested column as a nullable short.
@@ -164,7 +168,7 @@ inline fun Cursor.getLongOrNull(index: Int) = if (isNull(index)) null else getLo
  * @see Cursor.isNull
  * @see Cursor.getShort
  */
-inline fun Cursor.getShortOrNull(index: Int) = if (isNull(index)) null else getShort(index)
+inline fun Cursor.getShortOrNull(index: Int): Short? = if (isNull(index)) null else getShort(index)
 
 /**
  * Returns the value of the requested column as a nullable string.
@@ -175,7 +179,8 @@ inline fun Cursor.getShortOrNull(index: Int) = if (isNull(index)) null else getS
  * @see Cursor.isNull
  * @see Cursor.getString
  */
-inline fun Cursor.getStringOrNull(index: Int) = if (isNull(index)) null else getString(index)
+inline fun Cursor.getStringOrNull(index: Int): String? =
+    if (isNull(index)) null else getString(index)
 
 /**
  * Returns the value of the requested column as a nullable byte array.
@@ -187,7 +192,7 @@ inline fun Cursor.getStringOrNull(index: Int) = if (isNull(index)) null else get
  * @see Cursor.isNull
  * @see Cursor.getBlob
  */
-inline fun Cursor.getBlobOrNull(columnName: String) =
+inline fun Cursor.getBlobOrNull(columnName: String): ByteArray? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getBlob(it) }
 
 /**
@@ -200,7 +205,7 @@ inline fun Cursor.getBlobOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getDouble
  */
-inline fun Cursor.getDoubleOrNull(columnName: String) =
+inline fun Cursor.getDoubleOrNull(columnName: String): Double? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getDouble(it) }
 
 /**
@@ -213,7 +218,7 @@ inline fun Cursor.getDoubleOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getFloat
  */
-inline fun Cursor.getFloatOrNull(columnName: String) =
+inline fun Cursor.getFloatOrNull(columnName: String): Float? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getFloat(it) }
 
 /**
@@ -226,7 +231,7 @@ inline fun Cursor.getFloatOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getInt
  */
-inline fun Cursor.getIntOrNull(columnName: String) =
+inline fun Cursor.getIntOrNull(columnName: String): Int? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getInt(it) }
 
 /**
@@ -239,7 +244,7 @@ inline fun Cursor.getIntOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getLong
  */
-inline fun Cursor.getLongOrNull(columnName: String) =
+inline fun Cursor.getLongOrNull(columnName: String): Long? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getLong(it) }
 
 /**
@@ -252,7 +257,7 @@ inline fun Cursor.getLongOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getShort
  */
-inline fun Cursor.getShortOrNull(columnName: String) =
+inline fun Cursor.getShortOrNull(columnName: String): Short? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getShort(it) }
 
 /**
@@ -265,5 +270,5 @@ inline fun Cursor.getShortOrNull(columnName: String) =
  * @see Cursor.isNull
  * @see Cursor.getString
  */
-inline fun Cursor.getStringOrNull(columnName: String) =
+inline fun Cursor.getStringOrNull(columnName: String): String? =
     getColumnIndexOrThrow(columnName).let { if (isNull(it)) null else getString(it) }

--- a/src/main/java/androidx/graphics/Bitmap.kt
+++ b/src/main/java/androidx/graphics/Bitmap.kt
@@ -66,9 +66,8 @@ inline operator fun Bitmap.set(x: Int, y: Int, @ColorInt color: Int) = setPixel(
  *
  * @return The new scaled bitmap or the source bitmap if no scaling is required.
  */
-inline fun Bitmap.scale(width: Int, height: Int, filter: Boolean = true): Bitmap {
-    return Bitmap.createScaledBitmap(this, width, height, filter)
-}
+inline fun Bitmap.scale(width: Int, height: Int, filter: Boolean = true): Bitmap =
+    Bitmap.createScaledBitmap(this, width, height, filter)
 
 /**
  * Returns a mutable bitmap with the specified [width] and [height]. A config
@@ -84,9 +83,7 @@ inline fun createBitmap(
     width: Int,
     height: Int,
     config: Bitmap.Config = Bitmap.Config.ARGB_8888
-): Bitmap {
-    return Bitmap.createBitmap(width, height, config)
-}
+): Bitmap = Bitmap.createBitmap(width, height, config)
 
 /**
  * Returns a mutable bitmap with the specified [width] and [height]. The config,
@@ -108,6 +105,4 @@ inline fun createBitmap(
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
     hasAlpha: Boolean = true,
     colorSpace: ColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
-): Bitmap {
-    return Bitmap.createBitmap(width, height, config, hasAlpha, colorSpace)
-}
+): Bitmap = Bitmap.createBitmap(width, height, config, hasAlpha, colorSpace)

--- a/src/main/java/androidx/graphics/Color.kt
+++ b/src/main/java/androidx/graphics/Color.kt
@@ -36,7 +36,7 @@ import android.support.annotation.RequiresApi
  * ```
  */
 @RequiresApi(26)
-inline operator fun Color.component1() = getComponent(0)
+inline operator fun Color.component1(): Float = getComponent(0)
 
 /**
  * Returns the second component of the color. For instance, when the color model
@@ -50,7 +50,7 @@ inline operator fun Color.component1() = getComponent(0)
  * ```
  */
 @RequiresApi(26)
-inline operator fun Color.component2() = getComponent(1)
+inline operator fun Color.component2(): Float = getComponent(1)
 
 /**
  * Returns the third component of the color. For instance, when the color model
@@ -64,7 +64,7 @@ inline operator fun Color.component2() = getComponent(1)
  * ```
  */
 @RequiresApi(26)
-inline operator fun Color.component3() = getComponent(2)
+inline operator fun Color.component3(): Float = getComponent(2)
 
 /**
  * Returns the fourth component of the color. For instance, when the color model
@@ -78,7 +78,7 @@ inline operator fun Color.component3() = getComponent(2)
  * ```
  */
 @RequiresApi(26)
-inline operator fun Color.component4() = getComponent(3)
+inline operator fun Color.component4(): Float = getComponent(3)
 
 /**
  * Composites two translucent colors together. More specifically, adds two colors using
@@ -140,7 +140,7 @@ operator fun Color.plus(c: Color): Color {
  * Color.alpha(myInt)
  * ```
  */
-inline val @receiver:ColorInt Int.alpha get() = (this shr 24) and 0xff
+inline val @receiver:ColorInt Int.alpha: Int get() = (this shr 24) and 0xff
 
 /**
  * Return the red component of a color int. This is equivalent to calling:
@@ -148,7 +148,7 @@ inline val @receiver:ColorInt Int.alpha get() = (this shr 24) and 0xff
  * Color.red(myInt)
  * ```
  */
-inline val @receiver:ColorInt Int.red get() = (this shr 16) and 0xff
+inline val @receiver:ColorInt Int.red: Int get() = (this shr 16) and 0xff
 
 /**
  * Return the green component of a color int. This is equivalent to calling:
@@ -156,7 +156,7 @@ inline val @receiver:ColorInt Int.red get() = (this shr 16) and 0xff
  * Color.green(myInt)
  * ```
  */
-inline val @receiver:ColorInt Int.green get() = (this shr 8) and 0xff
+inline val @receiver:ColorInt Int.green: Int get() = (this shr 8) and 0xff
 
 /**
  * Return the blue component of a color int. This is equivalent to calling:
@@ -164,7 +164,7 @@ inline val @receiver:ColorInt Int.green get() = (this shr 8) and 0xff
  * Color.blue(myInt)
  * ```
  */
-inline val @receiver:ColorInt Int.blue get() = this and 0xff
+inline val @receiver:ColorInt Int.blue: Int get() = this and 0xff
 
 /**
  * Return the alpha component of a color int. This is equivalent to calling:
@@ -178,7 +178,7 @@ inline val @receiver:ColorInt Int.blue get() = this and 0xff
  * val (alpha, red, green, blue) = myColor
  * ```
  */
-inline operator fun @receiver:ColorInt Int.component1() = (this shr 24) and 0xff
+inline operator fun @receiver:ColorInt Int.component1(): Int = (this shr 24) and 0xff
 
 /**
  * Return the red component of a color int. This is equivalent to calling:
@@ -192,7 +192,7 @@ inline operator fun @receiver:ColorInt Int.component1() = (this shr 24) and 0xff
  * val (alpha, red, green, blue) = myColor
  * ```
  */
-inline operator fun @receiver:ColorInt Int.component2() = (this shr 16) and 0xff
+inline operator fun @receiver:ColorInt Int.component2(): Int = (this shr 16) and 0xff
 
 /**
  * Return the green component of a color int. This is equivalent to calling:
@@ -206,7 +206,7 @@ inline operator fun @receiver:ColorInt Int.component2() = (this shr 16) and 0xff
  * val (alpha, red, green, blue) = myColor
  * ```
  */
-inline operator fun @receiver:ColorInt Int.component3() = (this shr 8) and 0xff
+inline operator fun @receiver:ColorInt Int.component3(): Int = (this shr 8) and 0xff
 
 /**
  * Return the blue component of a color int. This is equivalent to calling:
@@ -220,7 +220,7 @@ inline operator fun @receiver:ColorInt Int.component3() = (this shr 8) and 0xff
  * val (alpha, red, green, blue) = myColor
  * ```
  */
-inline operator fun @receiver:ColorInt Int.component4() = this and 0xff
+inline operator fun @receiver:ColorInt Int.component4(): Int = this and 0xff
 
 /**
  * Returns the relative luminance of a color int, assuming sRGB encoding.
@@ -228,7 +228,8 @@ inline operator fun @receiver:ColorInt Int.component4() = this and 0xff
  * W3C Recommendation 11 December 2008.
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorInt Int.luminance get() = Color.luminance(this)
+inline val @receiver:ColorInt Int.luminance: Float
+    get() = Color.luminance(this)
 
 /**
  * Creates a new [Color] instance from a color int. The resulting color
@@ -243,7 +244,7 @@ inline fun @receiver:ColorInt Int.toColor(): Color = Color.valueOf(this)
  */
 @RequiresApi(26)
 @ColorLong
-inline fun @receiver:ColorInt Int.toColorLong() = Color.pack(this)
+inline fun @receiver:ColorInt Int.toColorLong(): Long = Color.pack(this)
 
 /**
  * Returns the first component of the color. For instance, when the color model
@@ -257,7 +258,7 @@ inline fun @receiver:ColorInt Int.toColorLong() = Color.pack(this)
  * ```
  */
 @RequiresApi(26)
-inline operator fun @receiver:ColorLong Long.component1() = Color.red(this)
+inline operator fun @receiver:ColorLong Long.component1(): Float = Color.red(this)
 
 /**
  * Returns the second component of the color. For instance, when the color model
@@ -271,7 +272,7 @@ inline operator fun @receiver:ColorLong Long.component1() = Color.red(this)
  * ```
  */
 @RequiresApi(26)
-inline operator fun @receiver:ColorLong Long.component2() = Color.green(this)
+inline operator fun @receiver:ColorLong Long.component2(): Float = Color.green(this)
 
 /**
  * Returns the third component of the color. For instance, when the color model
@@ -285,7 +286,7 @@ inline operator fun @receiver:ColorLong Long.component2() = Color.green(this)
  * ```
  */
 @RequiresApi(26)
-inline operator fun @receiver:ColorLong Long.component3() = Color.blue(this)
+inline operator fun @receiver:ColorLong Long.component3(): Float = Color.blue(this)
 
 /**
  * Returns the fourth component of the color. For instance, when the color model
@@ -299,7 +300,7 @@ inline operator fun @receiver:ColorLong Long.component3() = Color.blue(this)
  * ```
  */
 @RequiresApi(26)
-inline operator fun @receiver:ColorLong Long.component4() = Color.alpha(this)
+inline operator fun @receiver:ColorLong Long.component4(): Float = Color.alpha(this)
 
 /**
  * Return the alpha component of a color long. This is equivalent to calling:
@@ -308,7 +309,8 @@ inline operator fun @receiver:ColorLong Long.component4() = Color.alpha(this)
  * ```
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.alpha get() = Color.alpha(this)
+inline val @receiver:ColorLong Long.alpha: Float
+    get() = Color.alpha(this)
 
 /**
  * Return the red component of a color long. This is equivalent to calling:
@@ -317,7 +319,8 @@ inline val @receiver:ColorLong Long.alpha get() = Color.alpha(this)
  * ```
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.red get() = Color.red(this)
+inline val @receiver:ColorLong Long.red: Float
+    get() = Color.red(this)
 
 /**
  * Return the green component of a color long. This is equivalent to calling:
@@ -326,7 +329,8 @@ inline val @receiver:ColorLong Long.red get() = Color.red(this)
  * ```
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.green get() = Color.green(this)
+inline val @receiver:ColorLong Long.green: Float
+    get() = Color.green(this)
 
 /**
  * Return the blue component of a color long. This is equivalent to calling:
@@ -335,14 +339,16 @@ inline val @receiver:ColorLong Long.green get() = Color.green(this)
  * ```
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.blue get() = Color.blue(this)
+inline val @receiver:ColorLong Long.blue: Float
+    get() = Color.blue(this)
 
 /**
  * Returns the relative luminance of a color. Based on the formula for
  * relative luminance defined in WCAG 2.0, W3C Recommendation 11 December 2008.
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.luminance get() = Color.luminance(this)
+inline val @receiver:ColorLong Long.luminance: Float
+    get() = Color.luminance(this)
 
 /**
  * Creates a new [Color] instance from a [color long][Color].
@@ -355,26 +361,29 @@ inline fun @receiver:ColorLong Long.toColor(): Color = Color.valueOf(this)
  */
 @RequiresApi(26)
 @ColorInt
-inline fun @receiver:ColorLong Long.toColorInt() = Color.toArgb(this)
+inline fun @receiver:ColorLong Long.toColorInt(): Int = Color.toArgb(this)
 
 /**
  * Indicates whether the color is in the [sRGB][android.graphics.ColorSpace.Named.SRGB]
  * color space.
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.isSrgb get() = Color.isSrgb(this)
+inline val @receiver:ColorLong Long.isSrgb: Boolean
+    get() = Color.isSrgb(this)
 
 /**
  * Indicates whether the color is in a [wide-gamut][android.graphics.ColorSpace] color space.
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.isWideGamut get() = Color.isWideGamut(this)
+inline val @receiver:ColorLong Long.isWideGamut: Boolean
+    get() = Color.isWideGamut(this)
 
 /**
  * Returns the color space encoded in the specified color long.
  */
 @get:RequiresApi(26)
-inline val @receiver:ColorLong Long.colorSpace: ColorSpace get() = Color.colorSpace(this)
+inline val @receiver:ColorLong Long.colorSpace: ColorSpace
+    get() = Color.colorSpace(this)
 
 /**
  * Return a corresponding [Int] color of this [String].

--- a/src/main/java/androidx/graphics/Matrix.kt
+++ b/src/main/java/androidx/graphics/Matrix.kt
@@ -24,28 +24,29 @@ import android.graphics.Matrix
  * Multiplies this [Matrix] by another matrix and returns the result as
  * a new matrix.
  */
-inline operator fun Matrix.times(m: Matrix) = Matrix(this).apply { preConcat(m) }
+inline operator fun Matrix.times(m: Matrix): Matrix = Matrix(this).apply { preConcat(m) }
 
 /**
  * Returns the 9 values of this [Matrix] as a new array of floats.
  */
-inline fun Matrix.values() = FloatArray(9).apply { getValues(this) }
+inline fun Matrix.values(): FloatArray = FloatArray(9).apply { getValues(this) }
 
 /**
  * Creates a translation matrix with the translation amounts [tx] and [ty]
  * respectively on the `x` and `y` axis.
  */
-fun translationMatrix(tx: Float = 0.0f, ty: Float = 0.0f) = Matrix().apply { setTranslate(tx, ty) }
+fun translationMatrix(tx: Float = 0.0f, ty: Float = 0.0f): Matrix =
+    Matrix().apply { setTranslate(tx, ty) }
 
 /**
  * Creates a scale matrix with the scale factor [sx] and [sy] respectively on the
  * `x` and `y` axis.
  */
-fun scaleMatrix(sx: Float = 1.0f, sy: Float = 1.0f) = Matrix().apply { setScale(sx, sy) }
+fun scaleMatrix(sx: Float = 1.0f, sy: Float = 1.0f): Matrix = Matrix().apply { setScale(sx, sy) }
 
 /**
  * Creates a rotation matrix, defined by a rotation angle in degrees around the pivot
  * point located at the coordinates ([px], [py]).
  */
-fun rotationMatrix(degrees: Float, px: Float = 0.0f, py: Float = 0.0f) =
+fun rotationMatrix(degrees: Float, px: Float = 0.0f, py: Float = 0.0f): Matrix =
     Matrix().apply { setRotate(degrees, px, py) }

--- a/src/main/java/androidx/graphics/Path.kt
+++ b/src/main/java/androidx/graphics/Path.kt
@@ -74,45 +74,29 @@ fun Path.flatten(error: Float = 0.5f): Iterable<PathSegment> {
  * Returns the union of two paths as a new [Path].
  */
 @RequiresApi(19)
-inline operator fun Path.plus(p: Path): Path {
-    return Path(this).apply {
-        op(p, Path.Op.UNION)
-    }
-}
+inline operator fun Path.plus(p: Path): Path = Path(this).apply { op(p, Path.Op.UNION) }
 
 /**
  * Returns the difference of two paths as a new [Path].
  */
 @RequiresApi(19)
-inline operator fun Path.minus(p: Path): Path {
-    return Path(this).apply {
-        op(p, Path.Op.DIFFERENCE)
-    }
-}
+inline operator fun Path.minus(p: Path): Path = Path(this).apply { op(p, Path.Op.DIFFERENCE) }
 
 /**
  * Returns the union of two paths as a new [Path].
  */
 @RequiresApi(19)
-inline infix fun Path.and(p: Path) = this + p
+inline infix fun Path.and(p: Path): Path = this + p
 
 /**
  * Returns the intersection of two paths as a new [Path].
  * If the paths do not intersect, returns an empty path.
  */
 @RequiresApi(19)
-inline infix fun Path.or(p: Path): Path {
-    return Path().apply {
-        op(this@or, p, Path.Op.INTERSECT)
-    }
-}
+inline infix fun Path.or(p: Path): Path = Path().apply { op(this@or, p, Path.Op.INTERSECT) }
 
 /**
  * Returns the union minus the intersection of two paths as a new [Path].
  */
 @RequiresApi(19)
-inline infix fun Path.xor(p: Path): Path {
-    return Path(this).apply {
-        op(p, Path.Op.XOR)
-    }
-}
+inline infix fun Path.xor(p: Path): Path = Path(this).apply { op(p, Path.Op.XOR) }

--- a/src/main/java/androidx/graphics/Point.kt
+++ b/src/main/java/androidx/graphics/Point.kt
@@ -30,7 +30,7 @@ import android.graphics.PointF
  * val (x, y) = myPoint
  * ```
  */
-inline operator fun Point.component1() = this.x
+inline operator fun Point.component1(): Int = this.x
 
 /**
  * Returns the y coordinate of this point.
@@ -41,7 +41,7 @@ inline operator fun Point.component1() = this.x
  * val (x, y) = myPoint
  * ```
  */
-inline operator fun Point.component2() = this.y
+inline operator fun Point.component2(): Int = this.y
 
 /**
  * Returns the x coordinate of this point.
@@ -52,7 +52,7 @@ inline operator fun Point.component2() = this.y
  * val (x, y) = myPoint
  * ```
  */
-inline operator fun PointF.component1() = this.x
+inline operator fun PointF.component1(): Float = this.x
 
 /**
  * Returns the y coordinate of this point.
@@ -63,102 +63,70 @@ inline operator fun PointF.component1() = this.x
  * val (x, y) = myPoint
  * ```
  */
-inline operator fun PointF.component2() = this.y
+inline operator fun PointF.component2(): Float = this.y
 
 /**
  * Offsets this point by the specified point and returns the result as a new point.
  */
-inline operator fun Point.plus(p: Point): Point {
-    return Point(x, y).apply {
-        offset(p.x, p.y)
-    }
-}
+inline operator fun Point.plus(p: Point): Point = Point(x, y).apply { offset(p.x, p.y) }
 
 /**
  * Offsets this point by the specified point and returns the result as a new point.
  */
-inline operator fun PointF.plus(p: PointF): PointF {
-    return PointF(x, y).apply {
-        offset(p.x, p.y)
-    }
-}
+inline operator fun PointF.plus(p: PointF): PointF = PointF(x, y).apply { offset(p.x, p.y) }
 
 /**
  * Offsets this point by the specified amount on both X and Y axis and returns the
  * result as a new point.
  */
-inline operator fun Point.plus(xy: Int): Point {
-    return Point(x, y).apply {
-        offset(xy, xy)
-    }
-}
+inline operator fun Point.plus(xy: Int): Point = Point(x, y).apply { offset(xy, xy) }
 
 /**
  * Offsets this point by the specified amount on both X and Y axis and returns the
  * result as a new point.
  */
-inline operator fun PointF.plus(xy: Float): PointF {
-    return PointF(x, y).apply {
-        offset(xy, xy)
-    }
-}
+inline operator fun PointF.plus(xy: Float): PointF = PointF(x, y).apply { offset(xy, xy) }
 
 /**
  * Offsets this point by the negation of the specified point and returns the result
  * as a new point.
  */
-inline operator fun Point.minus(p: Point): Point {
-    return Point(x, y).apply {
-        offset(-p.x, -p.y)
-    }
-}
+inline operator fun Point.minus(p: Point): Point = Point(x, y).apply { offset(-p.x, -p.y) }
 
 /**
  * Offsets this point by the negation of the specified point and returns the result
  * as a new point.
  */
-inline operator fun PointF.minus(p: PointF): PointF {
-    return PointF(x, y).apply {
-        offset(-p.x, -p.y)
-    }
-}
+inline operator fun PointF.minus(p: PointF): PointF = PointF(x, y).apply { offset(-p.x, -p.y) }
 
 /**
  * Offsets this point by the negation of the specified amount on both X and Y axis and
  * returns the result as a new point.
  */
-inline operator fun Point.minus(xy: Int): Point {
-    return Point(x, y).apply {
-        offset(-xy, -xy)
-    }
-}
+inline operator fun Point.minus(xy: Int): Point = Point(x, y).apply { offset(-xy, -xy) }
 
 /**
  * Offsets this point by the negation of the specified amount on both X and Y axis and
  * returns the result as a new point.
  */
-inline operator fun PointF.minus(xy: Float): PointF {
-    return PointF(x, y).apply {
-        offset(-xy, -xy)
-    }
-}
+inline operator fun PointF.minus(xy: Float): PointF = PointF(x, y).apply { offset(-xy, -xy) }
 
 /**
  * Returns a new point representing the negation of this point.
  */
-inline operator fun Point.unaryMinus() = Point(-x, -y)
+inline operator fun Point.unaryMinus(): Point = Point(-x, -y)
 
 /**
  * Returns a new point representing the negation of this point.
  */
-inline operator fun PointF.unaryMinus() = PointF(-x, -y)
+inline operator fun PointF.unaryMinus(): PointF = PointF(-x, -y)
 
 /**
  * Returns a [PointF] representation of this point.
  */
-inline fun Point.toPointF() = PointF(this)
+inline fun Point.toPointF(): PointF = PointF(this)
 
 /**
  * Returns a [Point] representation of this point.
  */
-inline fun PointF.toPoint() = Point(x.toInt(), y.toInt())
+inline fun PointF.toPoint(): Point = Point(x.toInt(), y.toInt())

--- a/src/main/java/androidx/graphics/PorterDuff.kt
+++ b/src/main/java/androidx/graphics/PorterDuff.kt
@@ -26,10 +26,11 @@ import android.graphics.PorterDuffXfermode
  * Creates a new [PorterDuffXfermode] that uses this [PorterDuff.Mode] as the
  * alpha compositing or blending mode.
  */
-inline fun PorterDuff.Mode.toXfermode() = PorterDuffXfermode(this)
+inline fun PorterDuff.Mode.toXfermode(): PorterDuffXfermode = PorterDuffXfermode(this)
 
 /**
  * Creates a new [PorterDuffColorFilter] that uses this [PorterDuff.Mode] as the
  * alpha compositing or blending mode, and the specified [color].
  */
-inline fun PorterDuff.Mode.toColorFilter(color: Int) = PorterDuffColorFilter(color, this)
+inline fun PorterDuff.Mode.toColorFilter(color: Int): PorterDuffColorFilter =
+    PorterDuffColorFilter(color, this)

--- a/src/main/java/androidx/graphics/Rect.kt
+++ b/src/main/java/androidx/graphics/Rect.kt
@@ -35,7 +35,7 @@ import android.graphics.Region
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun Rect.component1() = this.left
+inline operator fun Rect.component1(): Int = this.left
 
 /**
  * Returns "top", the second component of the rectangle.
@@ -46,7 +46,7 @@ inline operator fun Rect.component1() = this.left
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun Rect.component2() = this.top
+inline operator fun Rect.component2(): Int = this.top
 
 /**
  * Returns "right", the third component of the rectangle.
@@ -57,7 +57,7 @@ inline operator fun Rect.component2() = this.top
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun Rect.component3() = this.right
+inline operator fun Rect.component3(): Int = this.right
 
 /**
  * Returns "bottom", the fourth component of the rectangle.
@@ -68,7 +68,7 @@ inline operator fun Rect.component3() = this.right
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun Rect.component4() = this.bottom
+inline operator fun Rect.component4(): Int = this.bottom
 
 /**
  * Returns "left", the first component of the rectangle.
@@ -79,7 +79,7 @@ inline operator fun Rect.component4() = this.bottom
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun RectF.component1() = this.left
+inline operator fun RectF.component1(): Float = this.left
 
 /**
  * Returns "top", the second component of the rectangle.
@@ -90,7 +90,7 @@ inline operator fun RectF.component1() = this.left
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun RectF.component2() = this.top
+inline operator fun RectF.component2(): Float = this.top
 
 /**
  * Returns "right", the third component of the rectangle.
@@ -101,7 +101,7 @@ inline operator fun RectF.component2() = this.top
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun RectF.component3() = this.right
+inline operator fun RectF.component3(): Float = this.right
 
 /**
  * Returns "bottom", the fourth component of the rectangle.
@@ -112,136 +112,89 @@ inline operator fun RectF.component3() = this.right
  * val (left, top, right, bottom) = myRectangle
  * ```
  */
-inline operator fun RectF.component4() = this.bottom
+inline operator fun RectF.component4(): Float = this.bottom
 
 /**
  * Performs the union of this rectangle and the specified rectangle and returns
  * the result as a new rectangle.
  */
-inline operator fun Rect.plus(r: Rect): Rect {
-    return Rect(this).apply {
-        union(r)
-    }
-}
+inline operator fun Rect.plus(r: Rect): Rect = Rect(this).apply { union(r) }
 
 /**
  * Performs the union of this rectangle and the specified rectangle and returns
  * the result as a new rectangle.
  */
-inline operator fun RectF.plus(r: RectF): RectF {
-    return RectF(this).apply {
-        union(r)
-    }
-}
+inline operator fun RectF.plus(r: RectF): RectF = RectF(this).apply { union(r) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the specified
  * amount on both X and Y axis.
  */
-inline operator fun Rect.plus(xy: Int): Rect {
-    return Rect(this).apply {
-        offset(xy, xy)
-    }
-}
+inline operator fun Rect.plus(xy: Int): Rect = Rect(this).apply { offset(xy, xy) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the specified
  * amount on both X and Y axis.
  */
-inline operator fun RectF.plus(xy: Float): RectF {
-    return RectF(this).apply {
-        offset(xy, xy)
-    }
-}
+inline operator fun RectF.plus(xy: Float): RectF = RectF(this).apply { offset(xy, xy) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the specified
  * point.
  */
-inline operator fun Rect.plus(xy: Point): Rect {
-    return Rect(this).apply {
-        offset(xy.x, xy.y)
-    }
-}
+inline operator fun Rect.plus(xy: Point): Rect = Rect(this).apply { offset(xy.x, xy.y) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the specified
  * point.
  */
-inline operator fun RectF.plus(xy: PointF): RectF {
-    return RectF(this).apply {
-        offset(xy.x, xy.y)
-    }
-}
+inline operator fun RectF.plus(xy: PointF): RectF = RectF(this).apply { offset(xy.x, xy.y) }
 
 /**
  * Returns the difference of this rectangle and the specified rectangle as a new region.
  */
-inline operator fun Rect.minus(r: Rect): Region {
-    return Region(this).apply {
-        op(r, Region.Op.DIFFERENCE)
-    }
-}
+inline operator fun Rect.minus(r: Rect): Region = Region(this).apply { op(r, Region.Op.DIFFERENCE) }
 
 /**
  * Returns the difference of this rectangle and the specified rectangle as a new region.
  * This rectangle is first converted to a [Rect] using [RectF.toRect].
  */
-inline operator fun RectF.minus(r: RectF): Region {
-    return Region(this.toRect()).apply {
-        op(r.toRect(), Region.Op.DIFFERENCE)
-    }
-}
+inline operator fun RectF.minus(r: RectF): Region =
+    Region(toRect()).apply { op(r.toRect(), Region.Op.DIFFERENCE) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the negation
  * of the specified amount on both X and Y axis.
  */
-inline operator fun Rect.minus(xy: Int): Rect {
-    return Rect(this).apply {
-        offset(-xy, -xy)
-    }
-}
+inline operator fun Rect.minus(xy: Int): Rect = Rect(this).apply { offset(-xy, -xy) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the negation
  * of the specified amount on both X and Y axis.
  */
-inline operator fun RectF.minus(xy: Float): RectF {
-    return RectF(this).apply {
-        offset(-xy, -xy)
-    }
-}
+inline operator fun RectF.minus(xy: Float): RectF = RectF(this).apply { offset(-xy, -xy) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the negation of
  * the specified point.
  */
-inline operator fun Rect.minus(xy: Point): Rect {
-    return Rect(this).apply {
-        offset(-xy.x, -xy.y)
-    }
-}
+inline operator fun Rect.minus(xy: Point): Rect = Rect(this).apply { offset(-xy.x, -xy.y) }
 
 /**
  * Returns a new rectangle representing this rectangle offset by the negation of
  * the specified point.
  */
-inline operator fun RectF.minus(xy: PointF): RectF {
-    return RectF(this).apply {
-        offset(-xy.x, -xy.y)
-    }
-}
+inline operator fun RectF.minus(xy: PointF): RectF = RectF(this).apply { offset(-xy.x, -xy.y) }
 
 /**
  * Returns the union of two rectangles as a new rectangle.
  */
-inline infix fun Rect.and(r: Rect) = this + r
+inline infix fun Rect.and(r: Rect): Rect = this + r
 
 /**
  * Returns the union of two rectangles as a new rectangle.
  */
-inline infix fun RectF.and(r: RectF) = this + r
+inline infix fun RectF.and(r: RectF): RectF = this + r
 
 /**
  * Returns the intersection of two rectangles as a new rectangle.
@@ -249,11 +202,7 @@ inline infix fun RectF.and(r: RectF) = this + r
  * rectangle.
  */
 @SuppressLint("CheckResult")
-inline infix fun Rect.or(r: Rect): Rect {
-    return Rect(this).apply {
-        intersect(r)
-    }
-}
+inline infix fun Rect.or(r: Rect): Rect = Rect(this).apply { intersect(r) }
 
 /**
  * Returns the intersection of two rectangles as a new rectangle.
@@ -261,30 +210,19 @@ inline infix fun Rect.or(r: Rect): Rect {
  * rectangle.
  */
 @SuppressLint("CheckResult")
-inline infix fun RectF.or(r: RectF): RectF {
-    return RectF(this).apply {
-        intersect(r)
-    }
-}
+inline infix fun RectF.or(r: RectF): RectF = RectF(this).apply { intersect(r) }
 
 /**
  * Returns the union minus the intersection of two rectangles as a new region.
  */
-inline infix fun Rect.xor(r: Rect): Region {
-    return Region(this).apply {
-        op(r, Region.Op.XOR)
-    }
-}
+inline infix fun Rect.xor(r: Rect): Region = Region(this).apply { op(r, Region.Op.XOR) }
 
 /**
  * Returns the union minus the intersection of two rectangles as a new region.
  * The two rectangles are first converted to [Rect] using [RectF.toRect].
  */
-inline infix fun RectF.xor(r: RectF): Region {
-    return Region(this.toRect()).apply {
-        op(r.toRect(), Region.Op.XOR)
-    }
-}
+inline infix fun RectF.xor(r: RectF): Region =
+    Region(this.toRect()).apply { op(r.toRect(), Region.Op.XOR) }
 
 /**
  * Returns true if the specified point is inside the rectangle.
@@ -292,7 +230,7 @@ inline infix fun RectF.xor(r: RectF): Region {
  * This means that for a point to be contained: left <= x < right and top <= y < bottom.
  * An empty rectangle never contains any point.
  */
-inline operator fun Rect.contains(p: Point) = contains(p.x, p.y)
+inline operator fun Rect.contains(p: Point): Boolean = contains(p.x, p.y)
 
 /**
  * Returns true if the specified point is inside the rectangle.
@@ -300,7 +238,7 @@ inline operator fun Rect.contains(p: Point) = contains(p.x, p.y)
  * This means that for a point to be contained: left <= x < right and top <= y < bottom.
  * An empty rectangle never contains any point.
  */
-inline operator fun RectF.contains(p: PointF) = contains(p.x, p.y)
+inline operator fun RectF.contains(p: PointF): Boolean = contains(p.x, p.y)
 
 /**
  * Returns a [RectF] representation of this rectangle.
@@ -320,16 +258,16 @@ inline fun RectF.toRect(): Rect {
 /**
  * Returns a [Region] representation of this rectangle.
  */
-inline fun Rect.toRegion() = Region(this)
+inline fun Rect.toRegion(): Region = Region(this)
 
 /**
  * Returns a [Region] representation of this rectangle. The resulting rect will be sized such
  * that this rect can fit within it.
  */
-inline fun RectF.toRegion() = Region(this.toRect())
+inline fun RectF.toRegion(): Region = Region(this.toRect())
 
 /**
  * Transform this rectangle in place using the supplied [Matrix] and returns
  * this rectangle.
  */
-inline fun RectF.transform(m: Matrix) = apply { m.mapRect(this@transform) }
+inline fun RectF.transform(m: Matrix): RectF = apply { m.mapRect(this@transform) }

--- a/src/main/java/androidx/graphics/Region.kt
+++ b/src/main/java/androidx/graphics/Region.kt
@@ -26,105 +26,72 @@ import android.graphics.RegionIterator
 /**
  * Return true if the region contains the specified [Point].
  */
-inline operator fun Region.contains(p: Point) = contains(p.x, p.y)
+inline operator fun Region.contains(p: Point): Boolean = contains(p.x, p.y)
 
 /**
  * Return the union of this region and the specified [Rect] as a new region.
  */
-inline operator fun Region.plus(r: Rect): Region {
-    return Region(this).apply {
-        union(r)
-    }
-}
+inline operator fun Region.plus(r: Rect): Region = Region(this).apply { union(r) }
 
 /**
  * Return the union of this region and the specified region as a new region.
  */
-inline operator fun Region.plus(r: Region): Region {
-    return Region(this).apply {
-        op(r, Region.Op.UNION)
-    }
-}
+inline operator fun Region.plus(r: Region): Region = Region(this).apply { op(r, Region.Op.UNION) }
 
 /**
  * Return the difference of this region and the specified [Rect] as a new region.
  */
-inline operator fun Region.minus(r: Rect): Region {
-    return Region(this).apply {
-        op(r, Region.Op.DIFFERENCE)
-    }
-}
+inline operator fun Region.minus(r: Rect): Region =
+    Region(this).apply { op(r, Region.Op.DIFFERENCE) }
 
 /**
  * Return the difference of this region and the specified region as a new region.
  */
-inline operator fun Region.minus(r: Region): Region {
-    return Region(this).apply {
-        op(r, Region.Op.DIFFERENCE)
-    }
-}
+inline operator fun Region.minus(r: Region): Region =
+    Region(this).apply { op(r, Region.Op.DIFFERENCE) }
 
 /**
  * Returns the negation of this region as a new region.
  */
-inline operator fun Region.unaryMinus(): Region {
-    return Region(bounds).apply {
-        op(this@unaryMinus, Region.Op.DIFFERENCE)
-    }
-}
+inline operator fun Region.unaryMinus(): Region =
+    Region(bounds).apply { op(this@unaryMinus, Region.Op.DIFFERENCE) }
 
 /**
  * Returns the negation of this region as a new region.
  */
-inline operator fun Region.not() = -this
+inline operator fun Region.not(): Region = -this
 
 /**
  * Return the union of this region and the specified [Rect] as a new region.
  */
-inline infix fun Region.and(r: Rect) = this + r
+inline infix fun Region.and(r: Rect): Region = this + r
 
 /**
  * Return the union of this region and the specified region as a new region.
  */
-inline infix fun Region.and(r: Region) = this + r
+inline infix fun Region.and(r: Region): Region = this + r
 
 /**
  * Return the intersection of this region and the specified [Rect] as a new region.
  */
-inline infix fun Region.or(r: Rect): Region {
-    return Region(this).apply {
-        op(r, Region.Op.INTERSECT)
-    }
-}
+inline infix fun Region.or(r: Rect): Region = Region(this).apply { op(r, Region.Op.INTERSECT) }
 
 /**
  * Return the intersection of this region and the specified region as a new region.
  */
-inline infix fun Region.or(r: Region): Region {
-    return Region(this).apply {
-        op(r, Region.Op.INTERSECT)
-    }
-}
+inline infix fun Region.or(r: Region): Region = Region(this).apply { op(r, Region.Op.INTERSECT) }
 
 /**
  * Return the union minus the intersection of this region and the specified [Rect]
  * as a new region.
  */
-inline infix fun Region.xor(r: Rect): Region {
-    return Region(this).apply {
-        op(r, Region.Op.XOR)
-    }
-}
+inline infix fun Region.xor(r: Rect): Region = Region(this).apply { op(r, Region.Op.XOR) }
 
 /**
  * Return the union minus the intersection of this region and the specified region
  * as a new region.
  */
-inline infix fun Region.xor(r: Region): Region {
-    return Region(this).apply {
-        op(r, Region.Op.XOR)
-    }
-}
+inline infix fun Region.xor(r: Region): Region = Region(this).apply { op(r, Region.Op.XOR) }
 
 /** Performs the given action on each rect in this region. */
 inline fun Region.forEach(action: (rect: Rect) -> Unit) {
@@ -139,7 +106,7 @@ inline fun Region.forEach(action: (rect: Rect) -> Unit) {
 }
 
 /** Returns an [Iterator] over the rects in this region. */
-operator fun Region.iterator() = object : Iterator<Rect> {
+operator fun Region.iterator(): Iterator<Rect> = object : Iterator<Rect> {
     private val iterator = RegionIterator(this@iterator)
     private val rect = Rect()
     private var hasMore = iterator.next(rect)

--- a/src/main/java/androidx/graphics/drawable/BitmapDrawable.kt
+++ b/src/main/java/androidx/graphics/drawable/BitmapDrawable.kt
@@ -23,4 +23,4 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 
 /** Create a [BitmapDrawable] from this [Bitmap]. */
-inline fun Bitmap.toDrawable(resources: Resources) = BitmapDrawable(resources, this)
+inline fun Bitmap.toDrawable(resources: Resources): BitmapDrawable = BitmapDrawable(resources, this)

--- a/src/main/java/androidx/graphics/drawable/ColorDrawable.kt
+++ b/src/main/java/androidx/graphics/drawable/ColorDrawable.kt
@@ -24,8 +24,8 @@ import android.support.annotation.ColorInt
 import android.support.annotation.RequiresApi
 
 /** Create a [ColorDrawable] from this color value. */
-inline fun @receiver:ColorInt Int.toDrawable() = ColorDrawable(this)
+inline fun @receiver:ColorInt Int.toDrawable(): ColorDrawable = ColorDrawable(this)
 
 /** Create a [ColorDrawable] from this [Color] (via [Color.toArgb]). */
 @RequiresApi(26)
-inline fun Color.toDrawable() = ColorDrawable(toArgb())
+inline fun Color.toDrawable(): ColorDrawable = ColorDrawable(toArgb())

--- a/src/main/java/androidx/graphics/drawable/Drawable.kt
+++ b/src/main/java/androidx/graphics/drawable/Drawable.kt
@@ -76,6 +76,4 @@ fun Drawable.updateBounds(
     @Px top: Int = bounds.top,
     @Px right: Int = bounds.right,
     @Px bottom: Int = bounds.bottom
-) {
-    setBounds(left, top, right, bottom)
-}
+) = setBounds(left, top, right, bottom)

--- a/src/main/java/androidx/os/Bundle.kt
+++ b/src/main/java/androidx/os/Bundle.kt
@@ -29,7 +29,7 @@ import java.io.Serializable
  *
  * @throws IllegalArgumentException When a value is not a supported type of [Bundle].
  */
-fun bundleOf(vararg pairs: Pair<String, Any?>) = Bundle(pairs.size).apply {
+fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle = Bundle(pairs.size).apply {
     for ((key, value) in pairs) {
         when (value) {
             null -> putString(key, null) // Any nullable type will suffice.

--- a/src/main/java/androidx/os/Handler.kt
+++ b/src/main/java/androidx/os/Handler.kt
@@ -51,9 +51,7 @@ inline fun Handler.postDelayed(
     delayInMillis: Long,
     token: Any? = null,
     crossinline action: () -> Unit
-) = Runnable { action() }.also {
-    postDelayed(it, token, delayInMillis)
-}
+): Runnable = Runnable { action() }.also { postDelayed(it, token, delayInMillis) }
 
 /**
  * Version of [Handler.postDelayed] which re-orders the parameters, allowing the action to be
@@ -72,7 +70,7 @@ inline fun Handler.postDelayed(
     unit: TimeUnit,
     token: Any? = null,
     crossinline action: () -> Unit
-) = postDelayed(unit.toMillis(amount), token, action)
+): Runnable = postDelayed(unit.toMillis(amount), token, action)
 
 /**
  * Version of [Handler.postDelayed] which re-orders the parameters, allowing the action to be
@@ -91,7 +89,7 @@ inline fun Handler.postDelayed(
     duration: Duration,
     token: Any? = null,
     crossinline action: () -> Unit
-) = postDelayed(duration.toMillis(), token, action)
+): Runnable = postDelayed(duration.toMillis(), token, action)
 
 /**
  * Version of [Handler.postAtTime] which re-orders the parameters, allowing the action to be
@@ -110,6 +108,6 @@ inline fun Handler.postAtTime(
     uptimeMillis: Long,
     token: Any? = null,
     crossinline action: () -> Unit
-) = Runnable { action() }.also {
+): Runnable = Runnable { action() }.also {
     postAtTime(it, token, uptimeMillis)
 }

--- a/src/main/java/androidx/os/PersistableBundle.kt
+++ b/src/main/java/androidx/os/PersistableBundle.kt
@@ -26,7 +26,7 @@ import android.support.annotation.RequiresApi
  * @throws IllegalArgumentException When a value is not a supported type of [PersistableBundle].
  */
 @RequiresApi(21)
-fun persistableBundleOf(vararg pairs: Pair<String, Any?>) = PersistableBundle(pairs.size).apply {
+fun persistableBundleOf(vararg pairs: Pair<String, Any?>): PersistableBundle = PersistableBundle(pairs.size).apply {
     for ((key, value) in pairs) {
         when (value) {
             null -> putString(key, null) // Any nullable type will suffice.

--- a/src/main/java/androidx/text/CharSequence.kt
+++ b/src/main/java/androidx/text/CharSequence.kt
@@ -25,7 +25,7 @@ import android.text.TextUtils
  *
  * @see TextUtils.isDigitsOnly
  */
-inline fun CharSequence.isDigitsOnly() = TextUtils.isDigitsOnly(this)
+inline fun CharSequence.isDigitsOnly(): Boolean = TextUtils.isDigitsOnly(this)
 
 /**
  * Returns the length that the specified [CharSequence] would have if spaces and ASCII control
@@ -33,4 +33,4 @@ inline fun CharSequence.isDigitsOnly() = TextUtils.isDigitsOnly(this)
  *
  * @see TextUtils.getTrimmedLength
  */
-inline fun CharSequence.trimmedLength() = TextUtils.getTrimmedLength(this)
+inline fun CharSequence.trimmedLength(): Int = TextUtils.getTrimmedLength(this)

--- a/src/main/java/androidx/text/SpannableStringBuilder.kt
+++ b/src/main/java/androidx/text/SpannableStringBuilder.kt
@@ -24,8 +24,8 @@ import android.text.SpannableStringBuilder
 import android.text.SpannedString
 import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
-import android.text.style.StrikethroughSpan
 import android.text.style.RelativeSizeSpan
+import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
 
@@ -78,24 +78,27 @@ inline fun SpannableStringBuilder.inSpans(
  *
  * @see SpannableStringBuilder.inSpans
  */
-inline fun SpannableStringBuilder.bold(builderAction: SpannableStringBuilder.() -> Unit) =
-    inSpans(StyleSpan(BOLD), builderAction = builderAction)
+inline fun SpannableStringBuilder.bold(
+    builderAction: SpannableStringBuilder.() -> Unit
+): SpannableStringBuilder = inSpans(StyleSpan(BOLD), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in an italic [StyleSpan].
  *
  * @see SpannableStringBuilder.inSpans
  */
-inline fun SpannableStringBuilder.italic(builderAction: SpannableStringBuilder.() -> Unit) =
-    inSpans(StyleSpan(ITALIC), builderAction = builderAction)
+inline fun SpannableStringBuilder.italic(
+    builderAction: SpannableStringBuilder.() -> Unit
+): SpannableStringBuilder = inSpans(StyleSpan(ITALIC), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in an [UnderlineSpan].
  *
  * @see SpannableStringBuilder.inSpans
  */
-inline fun SpannableStringBuilder.underline(builderAction: SpannableStringBuilder.() -> Unit) =
-    inSpans(UnderlineSpan(), builderAction = builderAction)
+inline fun SpannableStringBuilder.underline(
+    builderAction: SpannableStringBuilder.() -> Unit
+): SpannableStringBuilder = inSpans(UnderlineSpan(), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in a [ForegroundColorSpan].
@@ -105,7 +108,7 @@ inline fun SpannableStringBuilder.underline(builderAction: SpannableStringBuilde
 inline fun SpannableStringBuilder.color(
     @ColorInt color: Int,
     builderAction: SpannableStringBuilder.() -> Unit
-) = inSpans(ForegroundColorSpan(color), builderAction = builderAction)
+): SpannableStringBuilder = inSpans(ForegroundColorSpan(color), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in a [BackgroundColorSpan].
@@ -115,15 +118,16 @@ inline fun SpannableStringBuilder.color(
 inline fun SpannableStringBuilder.backgroundColor(
     @ColorInt color: Int,
     builderAction: SpannableStringBuilder.() -> Unit
-) = inSpans(BackgroundColorSpan(color), builderAction = builderAction)
+): SpannableStringBuilder = inSpans(BackgroundColorSpan(color), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in a [StrikethroughSpan].
  *
  * @see SpannableStringBuilder.inSpans
  */
-inline fun SpannableStringBuilder.strikeThrough(builderAction: SpannableStringBuilder.() -> Unit) =
-    inSpans(StrikethroughSpan(), builderAction = builderAction)
+inline fun SpannableStringBuilder.strikeThrough(
+    builderAction: SpannableStringBuilder.() -> Unit
+): SpannableStringBuilder = inSpans(StrikethroughSpan(), builderAction = builderAction)
 
 /**
  * Wrap appended text in [builderAction] in a [RelativeSizeSpan].
@@ -133,4 +137,4 @@ inline fun SpannableStringBuilder.strikeThrough(builderAction: SpannableStringBu
 inline fun SpannableStringBuilder.scale(
     proportion: Float,
     builderAction: SpannableStringBuilder.() -> Unit
-) = inSpans(RelativeSizeSpan(proportion), builderAction = builderAction)
+): SpannableStringBuilder = inSpans(RelativeSizeSpan(proportion), builderAction = builderAction)

--- a/src/main/java/androidx/transition/Transition.kt
+++ b/src/main/java/androidx/transition/Transition.kt
@@ -23,41 +23,31 @@ import android.transition.Transition
  * Add an action which will be invoked when this transition has ended.
  */
 @RequiresApi(19)
-fun Transition.doOnEnd(action: (transition: Transition) -> Unit) {
-    addListener(onEnd = action)
-}
+fun Transition.doOnEnd(action: (transition: Transition) -> Unit) = addListener(onEnd = action)
 
 /**
  * Add an action which will be invoked when this transition has started.
  */
 @RequiresApi(19)
-fun Transition.doOnStart(action: (transition: Transition) -> Unit) {
-    addListener(onStart = action)
-}
+fun Transition.doOnStart(action: (transition: Transition) -> Unit) = addListener(onStart = action)
 
 /**
  * Add an action which will be invoked when this transition has been cancelled.
  */
 @RequiresApi(19)
-fun Transition.doOnCancel(action: (transition: Transition) -> Unit) {
-    addListener(onCancel = action)
-}
+fun Transition.doOnCancel(action: (transition: Transition) -> Unit) = addListener(onCancel = action)
 
 /**
  * Add an action which will be invoked when this transition has resumed after a pause.
  */
 @RequiresApi(19)
-fun Transition.doOnResume(action: (transition: Transition) -> Unit) {
-    addListener(onResume = action)
-}
+fun Transition.doOnResume(action: (transition: Transition) -> Unit) = addListener(onResume = action)
 
 /**
  * Add an action which will be invoked when this transition has been paused.
  */
 @RequiresApi(19)
-fun Transition.doOnPause(action: (transition: Transition) -> Unit) {
-    addListener(onPause = action)
-}
+fun Transition.doOnPause(action: (transition: Transition) -> Unit) = addListener(onPause = action)
 
 /**
  * Add a listener to this Transition using the provided actions.

--- a/src/main/java/androidx/util/AtomicFile.kt
+++ b/src/main/java/androidx/util/AtomicFile.kt
@@ -47,20 +47,15 @@ inline fun AtomicFile.tryWrite(block: (out: FileOutputStream) -> Unit) {
  * Sets the content of this file as an [array] of bytes.
  */
 @RequiresApi(17)
-fun AtomicFile.writeBytes(array: ByteArray) {
-    tryWrite {
-        it.write(array)
-    }
-}
+fun AtomicFile.writeBytes(array: ByteArray) = tryWrite { it.write(array) }
 
 /**
  * Sets the content of this file as [text] encoded using UTF-8 or specified [charset].
  * If this file exists, it becomes overwritten.
  */
 @RequiresApi(17)
-fun AtomicFile.writeText(text: String, charset: Charset = Charsets.UTF_8) {
+fun AtomicFile.writeText(text: String, charset: Charset = Charsets.UTF_8) =
     writeBytes(text.toByteArray(charset))
-}
 
 /**
  * Gets the entire content of this file as a byte array.

--- a/src/main/java/androidx/util/LongSparseArray.kt
+++ b/src/main/java/androidx/util/LongSparseArray.kt
@@ -23,11 +23,11 @@ import android.util.LongSparseArray
 
 /** Returns the number of key/value pairs in the collection. */
 @get:RequiresApi(16)
-inline val <T> LongSparseArray<T>.size get() = size()
+inline val <T> LongSparseArray<T>.size: Int get() = size()
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(16)
-inline operator fun <T> LongSparseArray<T>.contains(key: Long) = indexOfKey(key) >= 0
+inline operator fun <T> LongSparseArray<T>.contains(key: Long): Boolean = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 @RequiresApi(16)
@@ -44,29 +44,29 @@ operator fun <T> LongSparseArray<T>.plus(other: LongSparseArray<T>): LongSparseA
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.containsKey(key: Long) = indexOfKey(key) >= 0
+inline fun <T> LongSparseArray<T>.containsKey(key: Long): Boolean = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.containsValue(value: T) = indexOfValue(value) != -1
+inline fun <T> LongSparseArray<T>.containsValue(value: T): Boolean = indexOfValue(value) != -1
 
 /** Return the value corresponding to [key], or [defaultValue] when not present. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.getOrDefault(key: Long, defaultValue: T) =
+inline fun <T> LongSparseArray<T>.getOrDefault(key: Long, defaultValue: T): T =
     get(key) ?: defaultValue
 
 /** Return the value corresponding to [key], or from [defaultValue] when not present. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.getOrElse(key: Long, defaultValue: () -> T) =
+inline fun <T> LongSparseArray<T>.getOrElse(key: Long, defaultValue: () -> T): T =
     get(key) ?: defaultValue()
 
 /** Return true when the collection contains no elements. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.isEmpty() = size() == 0
+inline fun <T> LongSparseArray<T>.isEmpty(): Boolean = size() == 0
 
 /** Return true when the collection contains elements. */
 @RequiresApi(16)
-inline fun <T> LongSparseArray<T>.isNotEmpty() = size() != 0
+inline fun <T> LongSparseArray<T>.isNotEmpty(): Boolean = size() != 0
 
 /** Removes the entry for [key] only if it is mapped to [value]. */
 @RequiresApi(16)

--- a/src/main/java/androidx/util/Pair.kt
+++ b/src/main/java/androidx/util/Pair.kt
@@ -29,7 +29,7 @@ import android.util.Pair
  * ```
  */
 @Suppress("HasPlatformType") // Intentionally propagating platform type with unknown nullability.
-inline operator fun <F, S> Pair<F, S>.component1() = first
+inline operator fun <F, S> Pair<F, S>.component1(): F = first
 
 /**
  * Returns the second component of the pair.
@@ -40,10 +40,10 @@ inline operator fun <F, S> Pair<F, S>.component1() = first
  * ```
  */
 @Suppress("HasPlatformType") // Intentionally propagating platform type with unknown nullability.
-inline operator fun <F, S> Pair<F, S>.component2() = second
+inline operator fun <F, S> Pair<F, S>.component2(): S = second
 
 /** Returns this [Pair] as a [kotlin.Pair]. */
-inline fun <F, S> Pair<F, S>.toKotlinPair() = kotlin.Pair(first, second)
+inline fun <F, S> Pair<F, S>.toKotlinPair(): kotlin.Pair<Any?, Any?> = kotlin.Pair(first, second)
 
 /** Returns this [kotlin.Pair] as an Android [Pair]. */
 // Note: the return type is explicitly specified here to prevent always seeing platform types.

--- a/src/main/java/androidx/util/Size.kt
+++ b/src/main/java/androidx/util/Size.kt
@@ -32,7 +32,7 @@ import android.util.SizeF
  * ```
  */
 @RequiresApi(21)
-inline operator fun Size.component1() = width
+inline operator fun Size.component1(): Int = width
 
 /**
  * Returns "height", the second component of this [Size].
@@ -44,7 +44,7 @@ inline operator fun Size.component1() = width
  * ```
  */
 @RequiresApi(21)
-inline operator fun Size.component2() = height
+inline operator fun Size.component2(): Int = height
 
 /**
  * Returns "width", the first component of this [SizeF].
@@ -56,7 +56,7 @@ inline operator fun Size.component2() = height
  * ```
  */
 @RequiresApi(21)
-inline operator fun SizeF.component1() = width
+inline operator fun SizeF.component1(): Float = width
 
 /**
  * Returns "height", the second component of this [SizeF].
@@ -68,4 +68,4 @@ inline operator fun SizeF.component1() = width
  * ```
  */
 @RequiresApi(21)
-inline operator fun SizeF.component2() = height
+inline operator fun SizeF.component2(): Float = height

--- a/src/main/java/androidx/util/SparseArray.kt
+++ b/src/main/java/androidx/util/SparseArray.kt
@@ -21,10 +21,10 @@ package androidx.util
 import android.util.SparseArray
 
 /** Returns the number of key/value pairs in the collection. */
-inline val <T> SparseArray<T>.size get() = size()
+inline val <T> SparseArray<T>.size: Int get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun <T> SparseArray<T>.contains(key: Int) = indexOfKey(key) >= 0
+inline operator fun <T> SparseArray<T>.contains(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun <T> SparseArray<T>.set(key: Int, value: T) = put(key, value)
@@ -38,23 +38,23 @@ operator fun <T> SparseArray<T>.plus(other: SparseArray<T>): SparseArray<T> {
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun <T> SparseArray<T>.containsKey(key: Int) = indexOfKey(key) >= 0
+inline fun <T> SparseArray<T>.containsKey(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
-inline fun <T> SparseArray<T>.containsValue(value: T) = indexOfValue(value) != -1
+inline fun <T> SparseArray<T>.containsValue(value: T): Boolean = indexOfValue(value) != -1
 
 /** Return the value corresponding to [key], or [defaultValue] when not present. */
-inline fun <T> SparseArray<T>.getOrDefault(key: Int, defaultValue: T) = get(key) ?: defaultValue
+inline fun <T> SparseArray<T>.getOrDefault(key: Int, defaultValue: T): T = get(key) ?: defaultValue
 
 /** Return the value corresponding to [key], or from [defaultValue] when not present. */
-inline fun <T> SparseArray<T>.getOrElse(key: Int, defaultValue: () -> T) =
+inline fun <T> SparseArray<T>.getOrElse(key: Int, defaultValue: () -> T): T =
     get(key) ?: defaultValue()
 
 /** Return true when the collection contains no elements. */
-inline fun <T> SparseArray<T>.isEmpty() = size() == 0
+inline fun <T> SparseArray<T>.isEmpty(): Boolean = size() == 0
 
 /** Return true when the collection contains elements. */
-inline fun <T> SparseArray<T>.isNotEmpty() = size() != 0
+inline fun <T> SparseArray<T>.isNotEmpty(): Boolean = size() != 0
 
 /** Removes the entry for [key] only if it is mapped to [value]. */
 fun <T> SparseArray<T>.remove(key: Int, value: T): Boolean {

--- a/src/main/java/androidx/util/SparseBooleanArray.kt
+++ b/src/main/java/androidx/util/SparseBooleanArray.kt
@@ -21,10 +21,10 @@ package androidx.util
 import android.util.SparseBooleanArray
 
 /** Returns the number of key/value pairs in the collection. */
-inline val SparseBooleanArray.size get() = size()
+inline val SparseBooleanArray.size: Int get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun SparseBooleanArray.contains(key: Int) = indexOfKey(key) >= 0
+inline operator fun SparseBooleanArray.contains(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun SparseBooleanArray.set(key: Int, value: Boolean) = put(key, value)
@@ -38,23 +38,24 @@ operator fun SparseBooleanArray.plus(other: SparseBooleanArray): SparseBooleanAr
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun SparseBooleanArray.containsKey(key: Int) = indexOfKey(key) >= 0
+inline fun SparseBooleanArray.containsKey(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
-inline fun SparseBooleanArray.containsValue(value: Boolean) = indexOfValue(value) != -1
+inline fun SparseBooleanArray.containsValue(value: Boolean): Boolean = indexOfValue(value) != -1
 
 /** Return the value corresponding to [key], or [defaultValue] when not present. */
-inline fun SparseBooleanArray.getOrDefault(key: Int, defaultValue: Boolean) = get(key, defaultValue)
+inline fun SparseBooleanArray.getOrDefault(key: Int, defaultValue: Boolean): Boolean =
+    get(key, defaultValue)
 
 /** Return the value corresponding to [key], or from [defaultValue] when not present. */
-inline fun SparseBooleanArray.getOrElse(key: Int, defaultValue: () -> Boolean) =
+inline fun SparseBooleanArray.getOrElse(key: Int, defaultValue: () -> Boolean): Boolean =
     indexOfKey(key).let { if (it != -1) valueAt(it) else defaultValue() }
 
 /** Return true when the collection contains no elements. */
-inline fun SparseBooleanArray.isEmpty() = size() == 0
+inline fun SparseBooleanArray.isEmpty(): Boolean = size() == 0
 
 /** Return true when the collection contains elements. */
-inline fun SparseBooleanArray.isNotEmpty() = size() != 0
+inline fun SparseBooleanArray.isNotEmpty(): Boolean = size() != 0
 
 /** Removes the entry for [key] only if it is mapped to [value]. */
 fun SparseBooleanArray.remove(key: Int, value: Boolean): Boolean {

--- a/src/main/java/androidx/util/SparseIntArray.kt
+++ b/src/main/java/androidx/util/SparseIntArray.kt
@@ -21,10 +21,10 @@ package androidx.util
 import android.util.SparseIntArray
 
 /** Returns the number of key/value pairs in the collection. */
-inline val SparseIntArray.size get() = size()
+inline val SparseIntArray.size: Int get() = size()
 
 /** Returns true if the collection contains [key]. */
-inline operator fun SparseIntArray.contains(key: Int) = indexOfKey(key) >= 0
+inline operator fun SparseIntArray.contains(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 inline operator fun SparseIntArray.set(key: Int, value: Int) = put(key, value)
@@ -38,23 +38,23 @@ operator fun SparseIntArray.plus(other: SparseIntArray): SparseIntArray {
 }
 
 /** Returns true if the collection contains [key]. */
-inline fun SparseIntArray.containsKey(key: Int) = indexOfKey(key) >= 0
+inline fun SparseIntArray.containsKey(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
-inline fun SparseIntArray.containsValue(value: Int) = indexOfValue(value) != -1
+inline fun SparseIntArray.containsValue(value: Int): Boolean = indexOfValue(value) != -1
 
 /** Return the value corresponding to [key], or [defaultValue] when not present. */
-inline fun SparseIntArray.getOrDefault(key: Int, defaultValue: Int) = get(key, defaultValue)
+inline fun SparseIntArray.getOrDefault(key: Int, defaultValue: Int): Int = get(key, defaultValue)
 
 /** Return the value corresponding to [key], or from [defaultValue] when not present. */
-inline fun SparseIntArray.getOrElse(key: Int, defaultValue: () -> Int) =
+inline fun SparseIntArray.getOrElse(key: Int, defaultValue: () -> Int): Int =
     indexOfKey(key).let { if (it != -1) valueAt(it) else defaultValue() }
 
 /** Return true when the collection contains no elements. */
-inline fun SparseIntArray.isEmpty() = size() == 0
+inline fun SparseIntArray.isEmpty(): Boolean = size() == 0
 
 /** Return true when the collection contains elements. */
-inline fun SparseIntArray.isNotEmpty() = size() != 0
+inline fun SparseIntArray.isNotEmpty(): Boolean = size() != 0
 
 /** Removes the entry for [key] only if it is mapped to [value]. */
 fun SparseIntArray.remove(key: Int, value: Int): Boolean {

--- a/src/main/java/androidx/util/SparseLongArray.kt
+++ b/src/main/java/androidx/util/SparseLongArray.kt
@@ -23,11 +23,11 @@ import android.util.SparseLongArray
 
 /** Returns the number of key/value entries in the collection. */
 @get:RequiresApi(18)
-inline val SparseLongArray.size get() = size()
+inline val SparseLongArray.size: Int get() = size()
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(18)
-inline operator fun SparseLongArray.contains(key: Int) = indexOfKey(key) >= 0
+inline operator fun SparseLongArray.contains(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Allows the use of the index operator for storing values in the collection. */
 @RequiresApi(18)
@@ -44,28 +44,28 @@ operator fun SparseLongArray.plus(other: SparseLongArray): SparseLongArray {
 
 /** Returns true if the collection contains [key]. */
 @RequiresApi(18)
-inline fun SparseLongArray.containsKey(key: Int) = indexOfKey(key) >= 0
+inline fun SparseLongArray.containsKey(key: Int): Boolean = indexOfKey(key) >= 0
 
 /** Returns true if the collection contains [value]. */
 @RequiresApi(18)
-inline fun SparseLongArray.containsValue(value: Long) = indexOfValue(value) != -1
+inline fun SparseLongArray.containsValue(value: Long): Boolean = indexOfValue(value) != -1
 
 /** Return the value corresponding to [key], or [defaultValue] when not present. */
 @RequiresApi(18)
-inline fun SparseLongArray.getOrDefault(key: Int, defaultValue: Long) = get(key, defaultValue)
+inline fun SparseLongArray.getOrDefault(key: Int, defaultValue: Long): Long = get(key, defaultValue)
 
 /** Return the value corresponding to [key], or from [defaultValue] when not present. */
 @RequiresApi(18)
-inline fun SparseLongArray.getOrElse(key: Int, defaultValue: () -> Long) =
+inline fun SparseLongArray.getOrElse(key: Int, defaultValue: () -> Long): Long =
     indexOfKey(key).let { if (it != -1) valueAt(it) else defaultValue() }
 
 /** Return true when the collection contains no elements. */
 @RequiresApi(18)
-inline fun SparseLongArray.isEmpty() = size() == 0
+inline fun SparseLongArray.isEmpty(): Boolean = size() == 0
 
 /** Return true when the collection contains elements. */
 @RequiresApi(18)
-inline fun SparseLongArray.isNotEmpty() = size() != 0
+inline fun SparseLongArray.isNotEmpty(): Boolean = size() != 0
 
 /** Removes the entry for [key] only if it is set to [value]. */
 @RequiresApi(18)

--- a/src/main/java/androidx/view/Menu.kt
+++ b/src/main/java/androidx/view/Menu.kt
@@ -40,13 +40,13 @@ operator fun Menu.contains(item: MenuItem): Boolean {
 }
 
 /** Returns the number of items in this menu. */
-inline val Menu.size get() = size()
+inline val Menu.size: Int get() = size()
 
 /** Returns true if this menu contains no items. */
-inline fun Menu.isEmpty() = size() == 0
+inline fun Menu.isEmpty(): Boolean = size() == 0
 
 /** Returns true if this menu contains one or more items. */
-inline fun Menu.isNotEmpty() = size() != 0
+inline fun Menu.isNotEmpty(): Boolean = size() != 0
 
 /** Performs the given action on each item in this menu. */
 inline fun Menu.forEach(action: (item: MenuItem) -> Unit) {
@@ -63,7 +63,7 @@ inline fun Menu.forEachIndexed(action: (index: Int, item: MenuItem) -> Unit) {
 }
 
 /** Returns a [MutableIterator] over the items in this menu. */
-operator fun Menu.iterator() = object : MutableIterator<MenuItem> {
+operator fun Menu.iterator(): MutableIterator<MenuItem> = object : MutableIterator<MenuItem> {
     private var index = 0
     override fun hasNext() = index < size()
     override fun next() = getItem(index++) ?: throw IndexOutOfBoundsException()

--- a/src/main/java/androidx/view/View.kt
+++ b/src/main/java/androidx/view/View.kt
@@ -34,7 +34,7 @@ import androidx.graphics.applyCanvas
  *
  * @see doOnLayout
  */
-inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) {
+inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) =
     addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
         override fun onLayoutChange(
             view: View,
@@ -51,7 +51,6 @@ inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) {
             action(view)
         }
     })
-}
 
 /**
  * Performs the given action when this view is laid out. If the view has been laid out and it
@@ -60,7 +59,7 @@ inline fun View.doOnNextLayout(crossinline action: (view: View) -> Unit) {
  *
  * @see doOnNextLayout
  */
-inline fun View.doOnLayout(crossinline action: (view: View) -> Unit) {
+inline fun View.doOnLayout(crossinline action: (view: View) -> Unit) =
     if (ViewCompat.isLaidOut(this) && !isLayoutRequested) {
         action(this)
     } else {
@@ -68,7 +67,6 @@ inline fun View.doOnLayout(crossinline action: (view: View) -> Unit) {
             action(it)
         }
     }
-}
 
 /**
  * Performs the given action when the view tree is about to be drawn.
@@ -110,9 +108,7 @@ inline fun View.updatePaddingRelative(
     @Px top: Int = paddingTop,
     @Px end: Int = paddingEnd,
     @Px bottom: Int = paddingBottom
-) {
-    setPaddingRelative(start, top, end, bottom)
-}
+) = setPaddingRelative(start, top, end, bottom)
 
 /**
  * Updates this view's padding. This version of the method allows using named parameters
@@ -125,18 +121,14 @@ inline fun View.updatePadding(
     @Px top: Int = paddingTop,
     @Px right: Int = paddingRight,
     @Px bottom: Int = paddingBottom
-) {
-    setPadding(left, top, right, bottom)
-}
+) = setPadding(left, top, right, bottom)
 
 /**
  * Sets the view's padding. This version of the method sets all axes to the provided size.
  *
  * @see View.setPadding
  */
-inline fun View.setPadding(@Px size: Int) {
-    setPadding(size, size, size, size)
-}
+inline fun View.setPadding(@Px size: Int) = setPadding(size, size, size, size)
 
 /**
  * Version of [View.postDelayed] which re-orders the parameters, allowing the action to be placed
@@ -269,9 +261,8 @@ inline var View.isGone: Boolean
  * @see View.getLayoutParams
  * @see View.setLayoutParams
  **/
-inline fun View.updateLayoutParams(block: ViewGroup.LayoutParams.() -> Unit) {
+inline fun View.updateLayoutParams(block: ViewGroup.LayoutParams.() -> Unit) =
     updateLayoutParams<ViewGroup.LayoutParams>(block)
-}
 
 /**
  * Executes [block] with a typed version of the View's layoutParams and reassigns the

--- a/src/main/java/androidx/view/ViewGroup.kt
+++ b/src/main/java/androidx/view/ViewGroup.kt
@@ -28,11 +28,11 @@ import android.view.ViewGroup
  *
  * @throws IndexOutOfBoundsException if index is less than 0 or greater than or equal to the count.
  */
-operator fun ViewGroup.get(index: Int) =
+operator fun ViewGroup.get(index: Int): View =
     getChildAt(index) ?: throw IndexOutOfBoundsException("Index: $index, Size: $childCount")
 
 /** Returns `true` if [view] is found in this view group. */
-inline operator fun ViewGroup.contains(view: View) = indexOfChild(view) != -1
+inline operator fun ViewGroup.contains(view: View): Boolean = indexOfChild(view) != -1
 
 /** Adds [view] to this view group. */
 inline operator fun ViewGroup.plusAssign(view: View) = addView(view)
@@ -41,13 +41,13 @@ inline operator fun ViewGroup.plusAssign(view: View) = addView(view)
 inline operator fun ViewGroup.minusAssign(view: View) = removeView(view)
 
 /** Returns the number of views in this view group. */
-inline val ViewGroup.size get() = childCount
+inline val ViewGroup.size: Int get() = childCount
 
 /** Returns true if this view group contains no views. */
-inline fun ViewGroup.isEmpty() = childCount == 0
+inline fun ViewGroup.isEmpty(): Boolean = childCount == 0
 
 /** Returns true if this view group contains one or more views. */
-inline fun ViewGroup.isNotEmpty() = childCount != 0
+inline fun ViewGroup.isNotEmpty(): Boolean = childCount != 0
 
 /** Performs the given action on each view in this view group. */
 inline fun ViewGroup.forEach(action: (view: View) -> Unit) {
@@ -64,7 +64,7 @@ inline fun ViewGroup.forEachIndexed(action: (index: Int, view: View) -> Unit) {
 }
 
 /** Returns a [MutableIterator] over the views in this view group. */
-operator fun ViewGroup.iterator() = object : MutableIterator<View> {
+operator fun ViewGroup.iterator(): MutableIterator<View> = object : MutableIterator<View> {
     private var index = 0
     override fun hasNext() = index < childCount
     override fun next() = getChildAt(index++) ?: throw IndexOutOfBoundsException()
@@ -83,9 +83,8 @@ val ViewGroup.children: Sequence<View>
  *
  * @see ViewGroup.MarginLayoutParams.setMargins
  */
-inline fun ViewGroup.MarginLayoutParams.setMargins(@Px size: Int) {
+inline fun ViewGroup.MarginLayoutParams.setMargins(@Px size: Int) =
     setMargins(size, size, size, size)
-}
 
 /**
  * Updates the margins in the [ViewGroup]'s [ViewGroup.MarginLayoutParams].
@@ -98,9 +97,7 @@ inline fun ViewGroup.MarginLayoutParams.updateMargins(
     @Px top: Int = topMargin,
     @Px right: Int = rightMargin,
     @Px bottom: Int = bottomMargin
-) {
-    setMargins(left, top, right, bottom)
-}
+) = setMargins(left, top, right, bottom)
 
 /**
  * Updates the relative margins in the ViewGroup's MarginLayoutParams.

--- a/src/main/java/androidx/widget/Toast.kt
+++ b/src/main/java/androidx/widget/Toast.kt
@@ -27,9 +27,8 @@ import android.widget.Toast
  *
  * @param duration Toast duration, defaults to [Toast.LENGTH_SHORT]
  */
-inline fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT): Toast {
-    return Toast.makeText(this, text, duration).apply { show() }
-}
+inline fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT): Toast =
+    Toast.makeText(this, text, duration).apply { show() }
 
 /**
  * Creates and shows a [Toast] with text from a resource
@@ -37,6 +36,5 @@ inline fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT)
  * @param resId Resource id of the string resource to use
  * @param duration Toast duration, defaults to [Toast.LENGTH_SHORT]
  */
-inline fun Context.toast(@StringRes resId: Int, duration: Int = Toast.LENGTH_SHORT): Toast {
-    return Toast.makeText(this, resId, duration).apply { show() }
-}
+inline fun Context.toast(@StringRes resId: Int, duration: Int = Toast.LENGTH_SHORT): Toast =
+    Toast.makeText(this, resId, duration).apply { show() }


### PR DESCRIPTION
Modify all code to specify return type that is not `Unit`. In some cases, doing so will provide null-safety. In most cases, it is easier to read. I strongly believe this is the way to go with all public APIs.

Also use assignment in functions whenever possible.