### PR TITLE
Add extensions for Intent creation

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -27,6 +27,11 @@ package androidx.core.content {
     method public static void withStyledAttributes(android.content.Context, @StyleRes int resourceId, int[] attrs, kotlin.jvm.functions.Function1<? super android.content.res.TypedArray,kotlin.Unit> block);
   }
 
+  public final class IntentKt {
+    ctor public IntentKt();
+    method public static android.content.Intent intentOf(String? action = "null", android.net.Uri? data = "null", String? type = "null", Integer? flags = "null", java.util.Set<java.lang.String> categories = "emptySet()", android.os.Bundle? extras = "null");
+  }
+
   public final class SharedPreferencesKt {
     ctor public SharedPreferencesKt();
     method public static void edit(android.content.SharedPreferences, boolean commit = "false", kotlin.jvm.functions.Function1<? super android.content.SharedPreferences.Editor,kotlin.Unit> action);

--- a/src/androidTest/java/androidx/core/content/ContextTest.kt
+++ b/src/androidTest/java/androidx/core/content/ContextTest.kt
@@ -16,10 +16,13 @@
 
 package androidx.core.content
 
+import android.content.Intent
+import android.net.Uri
 import android.support.test.InstrumentationRegistry
 import android.support.test.filters.SdkSuppress
 import android.test.mock.MockContext
 import androidx.core.kotlin.test.R
+import androidx.core.os.bundleOf
 import androidx.testutils.getAttributeSet
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -69,5 +72,29 @@ class ContextTest {
         context.withStyledAttributes(attrs, R.styleable.SampleAttrs, 0, 0) {
             assertTrue(getInt(R.styleable.SampleAttrs_sample, -1) != -1)
         }
+    }
+
+    @Test fun intentFor() {
+        val data = Uri.parse("uri")
+
+        val intent = context.intentFor<Unit>(
+            action = "action",
+            data = data,
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK,
+            type = "type",
+            categories = setOf("category1", "category2"),
+            extras = bundleOf("key1" to "value1", "key2" to "value2")
+        )
+
+        assertEquals("action", intent.action)
+        assertEquals(data, intent.data)
+        assertEquals(Intent.FLAG_ACTIVITY_CLEAR_TASK, intent.flags)
+        assertEquals("type", intent.type)
+        assertTrue(intent.hasCategory("category1"))
+        assertTrue(intent.hasCategory("category2"))
+        assertTrue(intent.hasExtra("key1"))
+        assertTrue(intent.hasExtra("key2"))
+        assertEquals(context.packageName, intent.component.packageName)
+        assertEquals(Unit::class.java.name, intent.component.className)
     }
 }

--- a/src/androidTest/java/androidx/core/content/IntentTest.kt
+++ b/src/androidTest/java/androidx/core/content/IntentTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.content
+
+import android.content.Intent
+import android.net.Uri
+import androidx.core.os.bundleOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IntentTest {
+
+    @Test
+    fun intentOf() {
+        val data = Uri.parse("uri")
+
+        val intent = intentOf(
+            action = "action",
+            data = data,
+            type = "type",
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK,
+            categories = setOf("category1", "category2"),
+            extras = bundleOf("key1" to "value1", "key2" to "value2")
+        )
+
+        assertEquals("action", intent.action)
+        assertEquals(data, intent.data)
+        assertEquals(Intent.FLAG_ACTIVITY_CLEAR_TASK, intent.flags)
+        assertEquals("type", intent.type)
+        assertTrue(intent.hasCategory("category1"))
+        assertTrue(intent.hasCategory("category2"))
+        assertTrue(intent.hasExtra("key1"))
+        assertTrue(intent.hasExtra("key2"))
+    }
+}

--- a/src/main/java/androidx/core/content/Context.kt
+++ b/src/main/java/androidx/core/content/Context.kt
@@ -17,7 +17,10 @@
 package androidx.core.content
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.TypedArray
+import android.net.Uri
+import android.os.Bundle
 import android.support.annotation.AttrRes
 import android.support.annotation.RequiresApi
 import android.support.annotation.StyleRes
@@ -90,4 +93,34 @@ inline fun Context.withStyledAttributes(
     } finally {
         typedArray.recycle()
     }
+}
+
+/**
+ * Creates an [Intent] for the component [T] with explicitly specified parameters
+ *
+ * @see [Intent.setAction]
+ * @see [Intent.setData]
+ * @see [Intent.setType]
+ * @see [Intent.setDataAndType]
+ * @see [Intent.addCategory]
+ * @see [Intent.putExtras]
+ */
+inline fun <reified T : Any> Context.intentFor(
+    action: String? = null,
+    data: Uri? = null,
+    flags: Int? = null,
+    type: String? = null,
+    categories: Set<String> = emptySet(),
+    extras: Bundle? = null
+): Intent {
+    val intent = intentOf(
+        action = action,
+        data = data,
+        flags = flags,
+        type = type,
+        categories = categories,
+        extras = extras
+    )
+    intent.setClass(this, T::class.java)
+    return intent
 }

--- a/src/main/java/androidx/core/content/Intent.kt
+++ b/src/main/java/androidx/core/content/Intent.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("NOTHING_TO_INLINE")
+
+package androidx.core.content
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+
+/**
+ * Creates an [Intent] with explicitly specified parameters
+ *
+ * @see [Intent.setAction]
+ * @see [Intent.setData]
+ * @see [Intent.setType]
+ * @see [Intent.setDataAndType]
+ * @see [Intent.addCategory]
+ * @see [Intent.putExtras]
+ */
+inline fun intentOf(
+    action: String? = null,
+    data: Uri? = null,
+    type: String? = null,
+    flags: Int? = null,
+    categories: Set<String> = emptySet(),
+    extras: Bundle? = null
+): Intent {
+    val intent = Intent()
+    action?.let(intent::setAction)
+
+    if (data != null && type != null) {
+        intent.setDataAndType(data, type)
+    } else {
+        data?.let(intent::setData)
+        type?.let(intent::setType)
+    }
+
+    flags?.let(intent::setFlags)
+    extras?.let(intent::putExtras)
+
+    categories.forEach { intent.addCategory(it) }
+    return intent
+}


### PR DESCRIPTION
Make creation of intents easier. Covers #166.
In case if intent is implicit or don't require any application component:
```kotlin
val intent = intentOf(
    action = "action",
    data = Uri.parse(...),
    categories = setOf("category"),
    extras = bundleOf("key" to "value")
)
```
In case if intent should be created for specific component of application, you can use extension for `Context`:
```kotlin
val intent = context.intentFor<MyActivity>(
     action = "action",
     flags = Intent.FLAG_ACTIVITY_CLEAR_TASK,
     extras = bundleOf("key" to "value")
)
```
Possible parameters: `action`, `data`, `type`, `categories`, `flags`, `extras`

Concerns: in case if you need simply start activity with just one extra, it will look a bit massive
```kotlin
startActivity(intentFor<MyActivity>(extras = bundleOf("key" to "value")))
```