### PR TITLE
Improve header comment  in Size.kt

### DIFF
--- a/src/main/java/androidx/core/util/Size.kt
+++ b/src/main/java/androidx/core/util/Size.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 20188 The Android Open Source Project
+ * Copyright (C) 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I changed header comment from 20188 to 2018 in Size.kt.

That’s because, I guess 20188 in header comment mean generated-date of this class.
So, it should be change.