### PR TITLE
Add View.setUsageHint() to describe click actions for TalkBack users

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -637,6 +637,8 @@ package androidx.core.view {
     method public static void setGone(android.view.View, boolean value);
     method public static void setInvisible(android.view.View, boolean value);
     method public static void setPadding(android.view.View, @Px int size);
+    method public static void setUsageHint(android.view.View, @StringRes Integer? clickLabel = "null", @StringRes Integer? longClickLabel = "null");
+    method public static void setUsageHint(android.view.View, CharSequence? clickLabel = "null", CharSequence? longClickLabel = "null");
     method public static void setVisible(android.view.View, boolean value);
     method public static android.graphics.Bitmap toBitmap(android.view.View, android.graphics.Bitmap.Config config = "Bitmap.Config.ARGB_8888");
     method public static void updateLayoutParams(android.view.View, kotlin.jvm.functions.Function1<? super android.view.ViewGroup.LayoutParams,kotlin.Unit> block);

--- a/src/androidTest/java/androidx/core/view/ViewTest.kt
+++ b/src/androidTest/java/androidx/core/view/ViewTest.kt
@@ -20,6 +20,7 @@ import android.graphics.Bitmap
 import android.support.test.InstrumentationRegistry
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import androidx.core.kotlin.test.R
@@ -244,5 +245,43 @@ class ViewTest {
 
         val resolvedText = context.getText(R.string.text)
         assertEquals(testView.announcement, resolvedText)
+    }
+
+    @Test fun usageHintClick() {
+        view.isClickable = true
+        view.setUsageHint("clicklabel")
+
+        assertViewHasAccessibilityActionWithLabel(
+            view,
+            AccessibilityNodeInfo.ACTION_CLICK,
+            "clicklabel"
+        )
+    }
+
+    @Test fun usageHintLongClick() {
+        view.isLongClickable = true
+        view.setUsageHint(longClickLabel = "longClickLabel")
+
+        assertViewHasAccessibilityActionWithLabel(
+            view,
+            AccessibilityNodeInfo.ACTION_LONG_CLICK,
+            "longClickLabel"
+        )
+    }
+
+    private fun assertViewHasAccessibilityActionWithLabel(
+        view: View,
+        actionId: Int,
+        expectedLabel: CharSequence
+    ) {
+        val accessibilityNodeInfo = view.createAccessibilityNodeInfo()
+        for (accessibilityAction in accessibilityNodeInfo.actionList) {
+            if (actionId == accessibilityAction.id) {
+                assertEquals(expectedLabel, accessibilityAction.label)
+                return
+            }
+        }
+        throw AssertionError("View did not contain AccessibilityAction with id" +
+                " $actionId and label $expectedLabel")
     }
 }

--- a/src/main/java/androidx/core/view/View.kt
+++ b/src/main/java/androidx/core/view/View.kt
@@ -22,7 +22,12 @@ import android.graphics.Bitmap
 import android.support.annotation.Px
 import android.support.annotation.RequiresApi
 import android.support.annotation.StringRes
+import android.support.v4.view.AccessibilityDelegateCompat
 import android.support.v4.view.ViewCompat
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_CLICK
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_LONG_CLICK
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
@@ -96,6 +101,39 @@ inline fun View.doOnPreDraw(crossinline action: (view: View) -> Unit) {
 inline fun View.announceForAccessibility(@StringRes resource: Int) {
     val announcement = resources.getString(resource)
     announceForAccessibility(announcement)
+}
+
+/**
+ * Sets an [AccessibilityDelegateCompat] with custom usage hints for click and long-click actions.
+ */
+fun View.setUsageHint(@StringRes clickLabel: Int? = null, @StringRes longClickLabel: Int? = null) {
+    val resolvedClickLabel = clickLabel?.let { resources.getString(it) }
+    val resolvedLongClickLabel = longClickLabel?.let { resources.getString(it) }
+    setUsageHint(resolvedClickLabel, resolvedLongClickLabel)
+}
+
+/**
+ * Sets an [AccessibilityDelegateCompat] with custom usage hints for click and long-click actions.
+ */
+fun View.setUsageHint(clickLabel: CharSequence? = null, longClickLabel: CharSequence? = null) {
+    ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {
+        override fun onInitializeAccessibilityNodeInfo(
+            host: View?,
+            info: AccessibilityNodeInfoCompat?
+        ) {
+            super.onInitializeAccessibilityNodeInfo(host, info)
+            if (host!!.isClickable) {
+                info?.addAction(
+                    AccessibilityActionCompat(ACTION_CLICK, clickLabel)
+                )
+            }
+            if (host.isLongClickable) {
+                info?.addAction(
+                    AccessibilityActionCompat(ACTION_LONG_CLICK, longClickLabel)
+                )
+            }
+        }
+    })
 }
 
 /**


### PR DESCRIPTION
Usage hints are used by TalkBack to describe the action that will be triggered on click or long click, e.g.:

`"The Matrix... <pause>... Double tap to start playing movie"`

where `"The Matrix"` is the content description and `"Double tap to start playing movie"` is the usage hint. 

Without a _custom_ hint set, it will read: `"The Matrix... <pause>... Double tap to activate"`.

---

**Java implementation:**

```java
    ...
    setUsageHint(movieItemView, "start playing movie", null);
}

private static void setUsageHint(View view, @Nullable CharSequence clickLabel, @Nullable CharSequence longClickLabel) {
    ViewCompat.setAccessibilityDelegate(
        this, new AccessibilityDelegateCompat() {
            @Override
            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
                super.onInitializeAccessibilityNodeInfo(host, info);

                if (host.isClickable()) {
                    info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, clickLabel));
                }

                if (host.isLongClickable()) {
                    info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, longClickLabel));
                }
            }
        }
    );
}
```

**with Kotlin-ktx**:

```
movieItemView.setUsageHint("start playing movie")
```
---

There are many more combinations of tests I can add but I dunno if it's too much. I am concerned that `View.kt` and consequently `ViewTest.kt` will get very large - is there some strategy to mitigate this or is it not considered an issue?

---

On pre-Lollipop, this behaviour is a no-op (handled by `ViewCompat`'s implementation of `AccessibilityDelegate` under the hood).