### PR TITLE
Simple inflate from ViewGroup

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -621,6 +621,7 @@ package androidx.core.view {
     method public static void setMargins(android.view.ViewGroup.MarginLayoutParams, @Px int size);
     method public static void updateMargins(android.view.ViewGroup.MarginLayoutParams, @Px int left = "leftMargin", @Px int top = "topMargin", @Px int right = "rightMargin", @Px int bottom = "bottomMargin");
     method @RequiresApi(17) public static void updateMarginsRelative(android.view.ViewGroup.MarginLayoutParams, @Px int start = "marginStart", @Px int top = "topMargin", @Px int end = "marginEnd", @Px int bottom = "bottomMargin");
+    method public static void inflate(android.view.ViewGroup, @LayoutRes int id, boolean attach = "false");
   }
 
   public final class ViewKt {

--- a/src/androidTest/java/androidx/core/view/ViewGroupTest.kt
+++ b/src/androidTest/java/androidx/core/view/ViewGroupTest.kt
@@ -16,11 +16,14 @@
 
 package androidx.core.view
 
+import android.content.res.Resources
 import android.support.test.InstrumentationRegistry
 import android.support.test.filters.SdkSuppress
+import android.view.InflateException
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.kotlin.test.R
 import androidx.testutils.assertThrows
 import androidx.testutils.fail
 import com.google.common.truth.Truth.assertThat
@@ -28,6 +31,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class ViewGroupTest {
@@ -260,5 +264,28 @@ class ViewGroupTest {
         assertEquals(40, layoutParams.bottomMargin)
         assertEquals(10, layoutParams.marginStart)
         assertEquals(30, layoutParams.marginEnd)
+    }
+
+    @Test fun inflate() {
+        viewGroup.removeAllViews()
+        assertEquals(0, viewGroup.childCount)
+
+        var view = viewGroup.inflate<ViewGroup>(R.layout.test_activity)
+        assertNotNull(view)
+        assertEquals(0, viewGroup.childCount)
+
+        view = viewGroup.inflate(R.layout.test_activity, true)
+        assertNotNull(view)
+        assertEquals(1, viewGroup.childCount)
+
+        try {
+            view.inflate<View>(-1)
+            fail("should throw exception")
+        } catch (e: Exception) {
+            when (e) {
+                is InflateException, is Resources.NotFoundException -> {}
+                else -> fail("should throw InflateException or Resources.NotFoundException")
+            }
+        }
     }
 }

--- a/src/main/java/androidx/core/view/ViewGroup.kt
+++ b/src/main/java/androidx/core/view/ViewGroup.kt
@@ -125,7 +125,7 @@ inline fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
 
 /**
  * Inflate a new view hierarchy from the specified xml resource with providing current `ViewGroup`
- * as optional parent for new view hierarchy
+ * as optional parent for a new view hierarchy
  *
  * @param id ID for an XML layout resource to load (e.g., `R.layout.main_page`)
  *

--- a/src/main/java/androidx/core/view/ViewGroup.kt
+++ b/src/main/java/androidx/core/view/ViewGroup.kt
@@ -18,8 +18,10 @@
 
 package androidx.core.view
 
+import android.support.annotation.LayoutRes
 import android.support.annotation.Px
 import android.support.annotation.RequiresApi
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 
@@ -119,4 +121,26 @@ inline fun ViewGroup.MarginLayoutParams.updateMarginsRelative(
     topMargin = top
     marginEnd = end
     bottomMargin = bottom
+}
+
+/**
+ * Inflate a new view hierarchy from the specified xml resource with providing current `ViewGroup`
+ * as optional parent for new view hierarchy
+ *
+ * @param id ID for an XML layout resource to load (e.g., `R.layout.main_page`)
+ *
+ * @param attach Whether the inflated hierarchy should be attached to the root parameter?
+ * If `false`, root is only used to create the correct subclass of `LayoutParams` for the root view
+ * in the XML.
+ *
+ * @return The root View of the inflated hierarchy. If root was supplied and [attach] is `true`,
+ * this is root; otherwise it is the root of the inflated XML file.
+ *
+ * @throws android.view.InflateException if there is an error.
+ *
+ * @see LayoutInflater.inflate
+ * */
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T : View> ViewGroup.inflate(@LayoutRes id: Int, attach: Boolean = false): T {
+    return LayoutInflater.from(context).inflate(id, this, attach) as T
 }


### PR DESCRIPTION
- create extension for inflate from ViewGroup

This is useful for creating `RecyclerView.ViewHolder`

```kotlin
override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
    return ViewHolder(parent.inflate(R.layout.item))
}
```