### PR TITLE
Recycle TypedArray instance even if use block threw an exception.

### DIFF
--- a/src/androidTest/java/androidx/core/content/res/TypedArrayTest.kt
+++ b/src/androidTest/java/androidx/core/content/res/TypedArrayTest.kt
@@ -218,4 +218,19 @@ class TypedArrayTest {
             array.recycle()
         }
     }
+
+    @Test fun useRecyclesArrayOnException() {
+        val attrs = context.getAttributeSet(R.layout.typed_array)
+        val array = context.obtainStyledAttributes(attrs, R.styleable.TypedArrayTypes)
+
+        assertThrows<IllegalArgumentException> {
+            array.use {
+                throw IllegalArgumentException("Use block threw an exception.")
+            }
+        }.hasMessageThat().isEqualTo("Use block threw an exception.")
+
+        assertThrows<RuntimeException> {
+            array.recycle()
+        }
+    }
 }


### PR DESCRIPTION
Current version of `TypedArray.use` extension function doesn't call `TypedArray.recycle` if exception was thrown. 
`Closeable.use` (which is referenced in a javadoc to `TypedArray.use`) calls `Closeable.close` in all cases, and if exception was thrown during closing it is also added to the primary exception.
New `TypedArray.use` implementation is consistent with `Closeable.use`.