### PR TITLE
Add Collection extension (runIfNotEmpty)

### DIFF
--- a/src/androidTest/java/androidx/core/util/CollectionsTest.kt
+++ b/src/androidTest/java/androidx/core/util/CollectionsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.util
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.*
+
+class CollectionsTest {
+
+    @Test
+    fun empty() {
+        val collection = Collections.emptyList<Any>()
+
+        collection.runIfNotEmpty {
+            Assert.fail()
+        }
+    }
+
+    @Test
+    fun nonEmpty() {
+        val collection = arrayListOf<Any>("foo", "bar")
+
+        collection.runIfNotEmpty {
+            Assert.assertEquals("foo", this[0])
+        }
+    }
+}

--- a/src/main/java/androidx/core/util/Collections.kt
+++ b/src/main/java/androidx/core/util/Collections.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.util
+
+/**
+ * Uses collections item only if collection is not empty.
+ */
+inline fun <C: Collection<Any>, R> C.runIfNotEmpty(action: C.() -> R) {
+    if (isNotEmpty()) {
+        action()
+    }
+}


### PR DESCRIPTION
I created an extension to handle empty collection.

### Usage 
```kotlin
val someCollection = arrayListOf<String>("foo", "bar")
someCollection.runIfNotEmpty {
     forEach {
        print(it)
     }
} 

val emptyCollection = Collections.emptyList<Any>()

emptyCollection.runIfNotEmpty {
       // skips this block
}
```