### PR TITLE
Add missing Menu extensions

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -601,10 +601,12 @@ package androidx.core.view {
     method public static void forEach(android.view.Menu, kotlin.jvm.functions.Function1<? super android.view.MenuItem,kotlin.Unit> action);
     method public static void forEachIndexed(android.view.Menu, kotlin.jvm.functions.Function2<? super java.lang.Integer,? super android.view.MenuItem,kotlin.Unit> action);
     method public static operator android.view.MenuItem get(android.view.Menu, int index);
+    method public static kotlin.sequences.Sequence<android.view.MenuItem> getChildren(android.view.Menu);
     method public static int getSize(android.view.Menu);
     method public static boolean isEmpty(android.view.Menu);
     method public static boolean isNotEmpty(android.view.Menu);
     method public static operator java.util.Iterator<android.view.MenuItem> iterator(android.view.Menu);
+    method public static operator void minusAssign(android.view.Menu, android.view.MenuItem item);
   }
 
   public final class ViewGroupKt {

--- a/src/androidTest/java/androidx/core/view/MenuTest.kt
+++ b/src/androidTest/java/androidx/core/view/MenuTest.kt
@@ -45,6 +45,20 @@ class MenuTest {
         assertTrue(item2 in menu)
     }
 
+    @Test fun minusAssign() {
+        val item1 = menu.add(NONE, 1, NONE, "")
+        val item2 = menu.add(NONE, 2, NONE, "")
+
+        assertEquals(2, menu.size)
+
+        menu -= item2
+        assertEquals(1, menu.size)
+        assertSame(item1, menu[0])
+
+        menu -= item1
+        assertEquals(0, menu.size)
+    }
+
     @Test fun size() {
         assertEquals(0, menu.size)
 
@@ -131,5 +145,18 @@ class MenuTest {
         iterator.remove()
         assertFalse(item2 in menu)
         assertEquals(0, menu.size())
+    }
+
+    @Test fun children() {
+        val items = listOf(
+            menu.add(NONE, 1, NONE, ""),
+            menu.add(NONE, 2, NONE, ""),
+            menu.add(NONE, 3, NONE, "")
+        )
+        items.forEach { menu.add(it.groupId, it.itemId, it.order, it.title) }
+
+        menu.children.forEachIndexed { index, child ->
+            assertSame(menu[index], child)
+        }
     }
 }

--- a/src/main/java/androidx/core/view/Menu.kt
+++ b/src/main/java/androidx/core/view/Menu.kt
@@ -39,6 +39,9 @@ operator fun Menu.contains(item: MenuItem): Boolean {
     return false
 }
 
+/** Removes [item] from this menu. */
+inline operator fun Menu.minusAssign(item: MenuItem) = removeItem(item.itemId)
+
 /** Returns the number of items in this menu. */
 inline val Menu.size get() = size()
 
@@ -69,3 +72,9 @@ operator fun Menu.iterator() = object : MutableIterator<MenuItem> {
     override fun next() = getItem(index++) ?: throw IndexOutOfBoundsException()
     override fun remove() = removeItem(--index)
 }
+
+/** Returns a [Sequence] over the items in this menu. */
+val Menu.children: Sequence<MenuItem>
+    get() = object : Sequence<MenuItem> {
+        override fun iterator() = this@children.iterator()
+    }


### PR DESCRIPTION
There is a missing possibility to make operations over a `Sequence` of menu items, due to missing `children` extension, so I've added it. Also `minusAssign`.