### PR TITLE
Add two more extensions for shared preferences.

### DIFF
--- a/src/androidTest/java/androidx/core/content/SharedPreferencesTest.kt
+++ b/src/androidTest/java/androidx/core/content/SharedPreferencesTest.kt
@@ -45,4 +45,36 @@ class SharedPreferencesTest {
         assertEquals("test_value", preferences.getString("test_key1", null))
         assertEquals(100, preferences.getInt("test_key2", 0))
     }
+
+    @Test fun putApply() {
+        val preferences = context.getSharedPreferences("prefs", 0)
+
+        preferences.put("test_key1", "test_value")
+        preferences.put("test_key2", 100)
+
+        assertEquals("test_value", preferences.getString("test_key1", null))
+        assertEquals(100, preferences.getInt("test_key2", 0))
+    }
+
+    @Test fun putCommit() {
+        val preferences = context.getSharedPreferences("prefs", 0)
+
+        preferences.put("test_key1", "test_value", commit = true)
+
+        assertEquals("test_value", preferences.getString("test_key1", null))
+    }
+
+    @Test fun getValue() {
+        val preferences = context.getSharedPreferences("prefs", 0)
+        val editor = preferences.edit()
+
+        editor.putString("test_key1", "test_value")
+        editor.putInt("test_key2", 100)
+        editor.putBoolean("test_key3", true)
+        editor.apply()
+
+        assertEquals("test_value", preferences.get("test_key1", ""))
+        assertEquals(true, preferences.get("test_key3", false))
+        assertEquals(100, preferences.get("test_key2", 0))
+    }
 }

--- a/src/main/java/androidx/core/content/SharedPreferences.kt
+++ b/src/main/java/androidx/core/content/SharedPreferences.kt
@@ -48,3 +48,39 @@ inline fun SharedPreferences.edit(
         editor.apply()
     }
 }
+
+/**
+ * Returns value of given key
+ */
+inline fun <reified T> SharedPreferences.get(key: String, default: T): T {
+    return when (T::class) {
+        Boolean::class -> getBoolean(key, default as Boolean) as T
+        String::class -> getString(key, default as String) as T
+        Int::class -> getString(key, default as String) as T
+        Float::class -> getFloat(key, default as Float) as T
+        Long::class -> getLong(key, default as Long) as T
+        else -> default
+    }
+}
+
+/**
+ * Allows editing of this preference instance with a call to [apply][SharedPreferences.Editor.apply]
+ * or [commit][SharedPreferences.Editor.commit] to persist the changes.
+ * Default behaviour is [apply][SharedPreferences.Editor.apply].
+ */
+@SuppressLint("ApplySharedPref")
+inline fun <reified T> SharedPreferences.put(key: String, value: T, commit: Boolean = false) {
+    val editor = edit()
+    when (T::class) {
+        Boolean::class.java -> editor.putBoolean(key, value as Boolean)
+        String::class.java -> editor.putString(key, value as String)
+        Float::class -> editor.putFloat(key, value as Float)
+        Int::class.java -> editor.putInt(key, value as Int)
+        Long::class -> editor.putLong(key, value as Long)
+    }
+    if (commit) {
+        editor.commit()
+    } else {
+        editor.apply()
+    }
+}


### PR DESCRIPTION
This adds two extensions to shared preferences for put/get all types with one method.

**Examples**:

`preferences.put("user_id", 100)`

`preferences.put("user_id", 100, commit = true)`

`val userId = preferences.get("user_id", -1)`