### PR TITLE
Adding function to seamlessly create BroadcastReceiver instances

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -16,6 +16,11 @@ package androidx.core.animation {
 
 package androidx.core.content {
 
+  public final class BroadcastReceiverKt {
+    ctor public BroadcastReceiverKt();
+    method public static android.content.BroadcastReceiver broadcastReceiver(kotlin.jvm.functions.Function2<? super android.content.Context,? super android.content.Intent,kotlin.Unit> onReceive);
+  }
+
   public final class ContentValuesKt {
     ctor public ContentValuesKt();
     method public static error.NonExistentClass contentValuesOf(kotlin.Pair<java.lang.String,?>... pairs);

--- a/src/androidTest/java/androidx/core/content/BroadcastReceiverTest.kt
+++ b/src/androidTest/java/androidx/core/content/BroadcastReceiverTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.content
+
+import android.content.Intent
+import android.content.IntentFilter
+import android.support.test.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BroadcastReceiverTest {
+    private val context = InstrumentationRegistry.getContext()
+
+    @Test fun broadcastReceiver() {
+        var called = false
+
+        val action = Intent.ACTION_MAIN
+
+        val mReceiver = broadcastReceiver { _, intent ->
+            if (intent.action == action) {
+                called = true
+            }
+        }
+
+        context.registerReceiver(mReceiver, IntentFilter(action))
+        context.sendBroadcast(Intent(action))
+
+        var time = 0
+        while (!called && time < 2000) {
+            Thread.sleep(10)
+            time += 10
+        }
+
+        assertTrue(called)
+    }
+}

--- a/src/main/java/androidx/core/content/BroadcastReceiver.kt
+++ b/src/main/java/androidx/core/content/BroadcastReceiver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.content
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Returns a [BroadcastReceiver] with the [BroadcastReceiver.onReceive] implemented in the anonymous
+ * inner class.
+ */
+inline fun broadcastReceiver(
+    crossinline onReceive: (context: Context, intent: Intent) -> Unit
+): BroadcastReceiver =
+    object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            onReceive(context, intent)
+        }
+    }


### PR DESCRIPTION
**Before:**
```kotlin
val mReceiver = object : BroadcastReceiver() {
    override fun onReceive(context: Context, intent: Intent) {
        // body
    }
}
```
**After:**
```kotlin
val mReceiver = broadcastReceiver { context, intent ->
    // body
}
```