### PR TITLE
Adding extension for timed logging

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -604,7 +604,8 @@ package androidx.core.util {
 
   public final class TimingLoggerKt {
     ctor public TimingLoggerKt();
-    method public static void log(android.util.TimingLogger, kotlin.Pair<java.lang.String,? extends kotlin.jvm.functions.Function0<kotlin.Unit>>... splits);
+    method public static void log(android.util.TimingLogger, kotlin.jvm.functions.Function1<? super android.util.TimingLogger,kotlin.Unit> work);
+    method public static void split(android.util.TimingLogger, String splitLabel, kotlin.jvm.functions.Function0<kotlin.Unit> work);
   }
 
 }

--- a/api/current.txt
+++ b/api/current.txt
@@ -602,6 +602,11 @@ package androidx.core.util {
     method @RequiresApi(18) public static kotlin.collections.LongIterator valueIterator(android.util.SparseLongArray);
   }
 
+  public final class TimingLoggerKt {
+    ctor public TimingLoggerKt();
+    method public static void log(android.util.TimingLogger, kotlin.Pair<java.lang.String,? extends kotlin.jvm.functions.Function0<kotlin.Unit>>... splits);
+  }
+
 }
 
 package androidx.core.view {

--- a/src/androidTest/java/androidx/core/util/TimingLoggerTest.kt
+++ b/src/androidTest/java/androidx/core/util/TimingLoggerTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.util
+
+import android.util.TimingLogger
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimingLoggerTest {
+    @Test fun timingLogger() {
+        val called = arrayOf(false, false, false)
+
+        val timingLogger = TimingLogger("TAG", "methodA")
+        timingLogger.log(
+            "work A" to {
+                called[0] = true
+            },
+            "work B" to {
+                called[1] = true
+            },
+            "work C" to {
+                called[2] = true
+            }
+        )
+
+        assertTrue(called.reduce(Boolean::and))
+    }
+}

--- a/src/androidTest/java/androidx/core/util/TimingLoggerTest.kt
+++ b/src/androidTest/java/androidx/core/util/TimingLoggerTest.kt
@@ -25,17 +25,17 @@ class TimingLoggerTest {
         val called = arrayOf(false, false, false)
 
         val timingLogger = TimingLogger("TAG", "methodA")
-        timingLogger.log(
-            "work A" to {
+        timingLogger.log {
+            split("work A") {
                 called[0] = true
-            },
-            "work B" to {
+            }
+            split("work B") {
                 called[1] = true
-            },
-            "work C" to {
+            }
+            split("work C") {
                 called[2] = true
             }
-        )
+        }
 
         assertTrue(called.reduce(Boolean::and))
     }

--- a/src/main/java/androidx/core/util/TimingLogger.kt
+++ b/src/main/java/androidx/core/util/TimingLogger.kt
@@ -22,12 +22,16 @@ import android.util.TimingLogger
  * Resets the timing logger instance before timing each of the given splits and subsequently
  * dumping the results to the log output.
  */
-@Suppress("NOTHING_TO_INLINE") // aliases to other public API
-inline fun TimingLogger.log(vararg splits: Pair<String, () -> Unit>) {
+inline fun TimingLogger.log(work: TimingLogger.() -> Unit) {
     this.reset()
-    splits.forEach {
-        it.second()
-        this.addSplit(it.first)
-    }
+    work()
     this.dumpToLog()
+}
+
+/**
+ * Times the given work and subsequently adds a split to the timing logger instance.
+ */
+inline fun TimingLogger.split(splitLabel: String, work: () -> Unit) {
+    work()
+    this.addSplit(splitLabel)
 }

--- a/src/main/java/androidx/core/util/TimingLogger.kt
+++ b/src/main/java/androidx/core/util/TimingLogger.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.core.util
+
+import android.util.TimingLogger
+
+/**
+ * Resets the timing logger instance before timing each of the given splits and subsequently
+ * dumping the results to the log output.
+ */
+@Suppress("NOTHING_TO_INLINE") // aliases to other public API
+inline fun TimingLogger.log(vararg splits: Pair<String, () -> Unit>) {
+    this.reset()
+    splits.forEach {
+        it.second()
+        this.addSplit(it.first)
+    }
+    this.dumpToLog()
+}


### PR DESCRIPTION
The primary benefit of this extension is relieving the burden of calling `reset` and `dumpToLog` before and after each sequence of timed splits (note that `TimingLogger` doesn't provide any other access functions so dumping to the log output is the only use case). Further, this API provides a more declarative approach to mapping split names to the actual work bodies.

**Before**
```kotlin
val timings = TimingLogger(TAG, "methodA")
// ...
timings.reset()
// ... do some work A ...
timings.addSplit("work A")
// ... do some work B ...
timings.addSplit("work B")
// ... do some work C ...
timings.addSplit("work C")
timings.dumpToLog()
```
**After**
```kotlin
val timings = TimingLogger(TAG, "methodA")
// ...
timings.log {
    split("work A") {
        // ... do some work A ...
    }
    split("work B") {
        // ... do some work B ...
    }
    split("work C") {
        // ... do some work C ...
    }
}
```