### PR TITLE
Adding extensions to check if the bitmap is empty or not

### DIFF
--- a/src/androidTest/java/androidx/core/graphics/BitmapTest.kt
+++ b/src/androidTest/java/androidx/core/graphics/BitmapTest.kt
@@ -19,7 +19,7 @@ package androidx.core.graphics
 import android.graphics.Bitmap
 import android.graphics.ColorSpace
 import android.support.test.filters.SdkSuppress
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Test
 
 class BitmapTest {
@@ -28,6 +28,19 @@ class BitmapTest {
         assertEquals(7, bitmap.width)
         assertEquals(9, bitmap.height)
         assertEquals(Bitmap.Config.ARGB_8888, bitmap.config)
+    }
+
+    @Test fun checkIsEmpty() {
+        val bitmap = createBitmap(7, 9)
+        assertFalse(bitmap.isEmpty())
+    }
+
+    @Test fun checkIsNullOrEmpty() {
+        var bitmap: Bitmap? = createBitmap(7, 9)
+        assertFalse(bitmap.isNullOrEmpty())
+
+        bitmap = null
+        assertTrue(bitmap.isNullOrEmpty())
     }
 
     @Test fun createWithConfig() {

--- a/src/main/java/androidx/core/graphics/Bitmap.kt
+++ b/src/main/java/androidx/core/graphics/Bitmap.kt
@@ -21,6 +21,7 @@ package androidx.core.graphics
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.ColorSpace
+import android.os.Build
 import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
 
@@ -47,6 +48,20 @@ inline fun Bitmap.applyCanvas(block: Canvas.() -> Unit): Bitmap {
  * is a [color int][android.graphics.Color] in the sRGB color space.
  */
 inline operator fun Bitmap.get(x: Int, y: Int) = getPixel(x, y)
+
+/**
+ * Check if the bitmap is empty.
+ */
+inline fun Bitmap.isEmpty(): Boolean = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+    byteCount == 0
+} else {
+    allocationByteCount == 0
+}
+
+/**
+ * Check if the bitmap is null or empty.
+ */
+inline fun Bitmap?.isNullOrEmpty(): Boolean = this == null || isEmpty()
 
 /**
  * Writes the specified [color int][android.graphics.Color] into the bitmap
@@ -81,9 +96,9 @@ inline fun Bitmap.scale(width: Int, height: Int, filter: Boolean = true): Bitmap
  * @return A new bitmap with the specified dimensions and config
  */
 inline fun createBitmap(
-    width: Int,
-    height: Int,
-    config: Bitmap.Config = Bitmap.Config.ARGB_8888
+        width: Int,
+        height: Int,
+        config: Bitmap.Config = Bitmap.Config.ARGB_8888
 ): Bitmap {
     return Bitmap.createBitmap(width, height, config)
 }
@@ -103,11 +118,11 @@ inline fun createBitmap(
  */
 @RequiresApi(26)
 inline fun createBitmap(
-    width: Int,
-    height: Int,
-    config: Bitmap.Config = Bitmap.Config.ARGB_8888,
-    hasAlpha: Boolean = true,
-    colorSpace: ColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        width: Int,
+        height: Int,
+        config: Bitmap.Config = Bitmap.Config.ARGB_8888,
+        hasAlpha: Boolean = true,
+        colorSpace: ColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
 ): Bitmap {
     return Bitmap.createBitmap(width, height, config, hasAlpha, colorSpace)
 }


### PR DESCRIPTION
Extension functions to check if the bitmap is empty or not using byte counts. See #568 .

## Usage:

```
if (bitmap.isEmpty()){
   // Did not read bitmap correctly.
}
```

#### or 

```
if (bitmap.isNullOrEmpty()){
   // Bitmap is either null or empty
}
```