### PR TITLE
Direct contributors to AOSP

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,5 @@
+ATTENTION: This repository is no longer accepting issues!
+
+Please file any bug reports or feature suggestions for core-ktx and the other "KTX" libraries at https://issuetracker.google.com/issues/new?component=396204
+
+Thanks!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+ATTENTION: This repository is no longer accepting pull requests!
+
+Please contribute to core-ktx and the other "KTX" libraries in AOSP by following the instructions in the README of https://android.googlesource.com/platform/frameworks/support/
+
+Thanks!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 Android KTX
 ===========
 
+**ATTENTION**: This repository is no longer being used for development, tracking issues, or
+accepting pull requests.
+
+Please file any bug reports or feature suggestions for core-ktx and the other "KTX" libraries at
+https://issuetracker.google.com/issues/new?component=396204
+
+Please contribute to core-ktx and the other "KTX" libraries in AOSP by following the instructions
+in the README of https://android.googlesource.com/platform/frameworks/support/
+
+Thanks!
+
+----
+
 A set of Kotlin extensions for Android app development. The goal of Android KTX is to make Android
 development with Kotlin more concise, pleasant, and idiomatic by leveraging the features of the
 language such as extension functions/properties, lambdas, named parameters, and parameter defaults.


### PR DESCRIPTION
All of the KTX libraries are now available in their actual development locations instead of only one in a mirror. Rejoice!